### PR TITLE
Add CLI output for XR IS-IS/BGP delete sample apps

### DIFF
--- a/samples/basic/ydk/models/clns/nc-delete-config-clns-isis-20-ydk.txt
+++ b/samples/basic/ydk/models/clns/nc-delete-config-clns-isis-20-ydk.txt
@@ -1,0 +1,2 @@
+no router isis DEFAULT
+end

--- a/samples/basic/ydk/models/ipv4/nc-delete-config-ipv4-bgp-20-ydk.txt
+++ b/samples/basic/ydk/models/ipv4/nc-delete-config-ipv4-bgp-20-ydk.txt
@@ -1,0 +1,2 @@
+no router bgp 65001
+end


### PR DESCRIPTION
Delete apps for XR IS-IS/BGP were missing CLI output.  The text captured
in the files reflect the BGP AS and ISIS instance name that were defined
on the device when the delete application was executed.
