### PR TITLE
Add XR interface configuration apps

### DIFF
--- a/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-11-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-11-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-create-config-ifmgr-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()  # create config object
+    config_interface_configurations(interface_configurations)  # add object configuration
+
+    # crud.create(provider, interface_configurations)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-32-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-32-ydk.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-create-config-ifmgr-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv6 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "Loopback0"
+    interface_configuration.interface_virtual = Empty()
+    interface_configuration.description = "PRIMARY ROUTER LOOPBACK"
+    addresses = interface_configuration.ipv6_network.addresses
+    regular_address = addresses.regular_addresses.RegularAddress()
+    regular_address.address = "2001:db8::ff:1"
+    regular_address.prefix_length = 128
+    addresses.regular_addresses.regular_address.append(regular_address)
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    crud.create(provider, interface_configurations)  # create object on device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-32-ydk.txt
+++ b/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-32-ydk.txt
@@ -1,0 +1,6 @@
+interface Loopback0
+ description PRIMARY ROUTER LOOPBACK
+ ipv6 address 2001:db8::ff:1/128
+!
+end
+

--- a/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-36-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-36-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-create-config-ifmgr-36-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv6 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "GigabitEthernet0/0/0/0"
+    interface_configuration.description = "CONNECTS TO LSR1 (g0/0/0/1)"
+    mtu = interface_configuration.mtus.Mtu()
+    mtu.owner = "GigabitEthernet"
+    mtu.mtu = 9192
+    interface_configuration.mtus.mtu.append(mtu)
+    addresses = interface_configuration.ipv6_network.addresses
+    regular_address = addresses.regular_addresses.RegularAddress()
+    regular_address.address = "2001:db8::1:0"
+    regular_address.prefix_length = 127
+    addresses.regular_addresses.regular_address.append(regular_address)
+    interface_configuration.statistics.load_interval = 30
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    crud.create(provider, interface_configurations)  # create object on device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-36-ydk.txt
+++ b/samples/basic/ydk/models/ifmgr/nc-create-config-ifmgr-36-ydk.txt
@@ -1,0 +1,8 @@
+interface GigabitEthernet0/0/0/0
+ description CONNECTS TO LSR1 (g0/0/0/1)
+ mtu 9192
+ ipv6 address 2001:db8::1:0/127
+ load-interval 30
+!
+end
+

--- a/samples/basic/ydk/models/ifmgr/nc-delete-config-ifmgr-11-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-delete-config-ifmgr-11-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-delete-config-ifmgr-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()  # create config object
+    # crud.delete(provider, interface_configurations)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-read-config-ifmgr-11-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-read-config-ifmgr-11-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-read-config-ifmgr-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def process_interface_configurations(interface_configurations):
+    """Process data in interface_configurations object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()  # create config object
+    # interface_configurations = crud.read(provider, interface_configurations)  # read object from NETCONF device
+    process_interface_configurations(interface_configurations)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-read-oper-ifmgr-11-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-read-oper-ifmgr-11-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ifmgr-oper.
+
+usage: nc-read-oper-ifmgr-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_oper as xr_ifmgr_oper
+import logging
+
+
+def process_interface_properties(interface_properties):
+    """Process data in interface_properties object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    interface_properties = xr_ifmgr_oper.InterfaceProperties()  # create oper object
+    # interface_properties = crud.read(provider, interface_properties)  # read object from NETCONF device
+    process_interface_properties(interface_properties)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ifmgr/nc-update-config-ifmgr-11-ydk.py
+++ b/samples/basic/ydk/models/ifmgr/nc-update-config-ifmgr-11-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: nc-update-config-ifmgr-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()  # create config object
+    config_interface_configurations(interface_configurations)  # add object configuration
+
+    # crud.update(provider, interface_configurations)  # update object on NETCONF device
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps for CRUD operations, plus two custom
apps to create IPv6 interface configurations using the XR native
interface model (Cisco-IOS-XR-ifmgr-cfg):
nc-create-config-ifmgr-32-ydk.py - virtual interface (loo)
nc-create-config-ifmgr-36-ydk.py - physical interface (ge0/0/0/0)
