### PR TITLE
Fix clock source format

### DIFF
--- a/samples/basic/ydk/models/shellutil/nc-read-oper-shellutil-20-ydk.py
+++ b/samples/basic/ydk/models/shellutil/nc-read-oper-shellutil-20-ydk.py
@@ -69,7 +69,7 @@ def process_system_time(system_time):
                                    time=clock_time,
                                    tzone=system_time.clock.time_zone,
                                    date=clock_date,
-                                   source=system_time.clock.time_source,
+                                   source=system_time.clock.time_source.name,
                                    uptime=clock_delta))
 
 


### PR DESCRIPTION
Display source name (e.g. calendar, etc) instead of numeric value or
data type (e.g. enum).
