### PR TITLE
Add XR static route configuration apps

### DIFF
--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-10-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-create-config-ip-static-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    # crud.create(provider, router_static)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-21-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-21-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-create-config-ip-static-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "::"
+    vrf_prefix.prefix_length = 0
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    crud.create(provider, router_static)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-21-ydk.txt
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-21-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  ::/0 2001:db8::1:3
+ !
+!
+end
+

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-23-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-23-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-create-config-ip-static-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_interface_name = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopInterfaceName()
+    vrf_next_hop_interface_name.interface_name = "Null0"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_interface_name. \
+        append(vrf_next_hop_interface_name)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    crud.create(provider, router_static)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-23-ydk.txt
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-23-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  2001:db8:a::/64 Null0
+ !
+!
+end
+

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-25-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-25-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-create-config-ip-static-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_next_hop_next_hop_address.metric = 254
+    vrf_next_hop_next_hop_address.object_name = "TRACKED_OBJ"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    crud.create(provider, router_static)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-create-config-ip-static-25-ydk.txt
+++ b/samples/basic/ydk/models/ip/nc-create-config-ip-static-25-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  2001:db8:a::/64 2001:db8::1:3 254 track TRACKED_OBJ
+ !
+!
+end
+

--- a/samples/basic/ydk/models/ip/nc-delete-config-ip-static-10-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-delete-config-ip-static-10-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-delete-config-ip-static-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    # crud.delete(provider, router_static)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-delete-config-ip-static-21-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-delete-config-ip-static-21-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-delete-config-ip-static-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+
+    # delete object on NETCONF device
+    crud.delete(provider,
+                router_static.default_vrf.address_family.vrfipv6.vrf_unicast)
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-delete-config-ip-static-21-ydk.txt
+++ b/samples/basic/ydk/models/ip/nc-delete-config-ip-static-21-ydk.txt
@@ -1,0 +1,9 @@
+router static
+ address-family ipv6 unicast
+  no ::/0 2001:db8::1:3
+  no 2001:db8:a::/64 Null0
+  no 2001:db8:a::/64 2001:db8::1:3 254 track TRACKED_OBJ
+ !
+!
+end
+

--- a/samples/basic/ydk/models/ip/nc-read-config-ip-static-10-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-read-config-ip-static-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-read-config-ip-static-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def process_router_static(router_static):
+    """Process data in router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    # router_static = crud.read(provider, router_static)  # read object from NETCONF device
+    process_router_static(router_static)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/ip/nc-update-config-ip-static-10-ydk.py
+++ b/samples/basic/ydk/models/ip/nc-update-config-ip-static-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: nc-update-config-ip-static-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    # crud.update(provider, router_static)  # update object on NETCONF device
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps for CRUD operations, plus four custom
apps to create and delete IPv6 static route configurations using the XR
native model (Cisco_IOS_XR_ip_static_cfg):
nc-create-config-ip-static-21-ydk.py - route to next-hop address
nc-create-config-ip-static-23-ydk.py - route to Null0
nc-create-config-ip-static-25-ydk.py - route with attributes
nc-delete-config-ip-static-21-ydk.py - delete IPv6 static routes
