### PR TITLE
Add sample apps for OpenConfig routing policy model

### DIFF
--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-routing-policy.
+
+usage: nc-create-config-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # crud.create(provider, routing_policy)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-22-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-22-ydk.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-routing-policy.
+
+usage: nc-create-config-routing-policy-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure routing policy
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY1"
+    statement = policy_definition.statements.Statement()
+    statement.name = "accept route"
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    crud.create(provider, routing_policy)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-22-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-22-ydk.txt
@@ -1,0 +1,6 @@
+route-policy POLICY1
+  #statement-name accept route
+  done
+end-policy
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-24-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-24-ydk.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-routing-policy.
+
+usage: nc-create-config-routing-policy-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure as-path set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    as_path_set = bgp_defined_sets.as_path_sets.AsPathSet()
+    as_path_set.as_path_set_name = "AS-PATH-SET1"
+    as_path_set.as_path_set_member.append("^65172")
+    bgp_defined_sets.as_path_sets.as_path_set.append(as_path_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET1"
+    community_set.community_member.append("ios-regex '^65172:17...$'")
+    community_set.community_member.append("65172:16001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY2"
+    # community-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "community-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_community_set = bgp_conditions.MatchCommunitySet()
+    match_community_set.community_set = "COMMUNITY-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ALL
+    match_community_set.match_set_options = match_set_options
+    bgp_conditions.match_community_set = match_community_set
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # as-path-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "as-path-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_as_path_set = bgp_conditions.MatchAsPathSet()
+    match_as_path_set.as_path_set = "AS-PATH-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ANY
+    match_as_path_set.match_set_options = match_set_options
+    bgp_conditions.match_as_path_set = match_as_path_set
+    statement.actions.bgp_actions.set_local_pref = 50
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject route"
+    statement.actions.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    crud.create(provider, routing_policy)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-24-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-24-ydk.txt
@@ -1,0 +1,24 @@
+as-path-set AS-PATH-SET1
+  ios-regex '^65172'
+end-set
+!
+community-set COMMUNITY-SET1
+  ios-regex '^65172:17...$',
+  65172:16001
+end-set
+!
+route-policy POLICY2
+  #statement-name community-set1
+  if community matches-every COMMUNITY-SET1 then
+    done
+  endif
+  #statement-name as-path-set1
+  if as-path in AS-PATH-SET1 then
+    set local-preference 50
+    done
+  endif
+  #statement-name reject route
+  drop
+end-policy
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-26-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-26-ydk.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-routing-policy.
+
+usage: nc-create-config-routing-policy-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure prefix set
+    prefix_set = routing_policy.defined_sets.prefix_sets.PrefixSet()
+    prefix_set.prefix_set_name = "PREFIX-SET1"
+    prefix = prefix_set.Prefix()
+    prefix.ip_prefix = "10.0.0.0/16"
+    prefix.masklength_range = "24..32"
+    prefix_set.prefix.append(prefix)
+    prefix = prefix_set.Prefix()
+    prefix.ip_prefix = "172.0.0.0/8"
+    prefix.masklength_range = "16..32"
+    prefix_set.prefix.append(prefix)
+    routing_policy.defined_sets.prefix_sets.prefix_set.append(prefix_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET2"
+    community_set.community_member.append("65172:17001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY3"
+    # prefix-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "prefix-set1"
+    match_prefix_set = statement.conditions.MatchPrefixSet()
+    match_prefix_set.prefix_set = "PREFIX-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsRestrictedTypeEnum.ANY
+    match_prefix_set.match_set_options = match_set_options
+    statement.conditions.match_prefix_set = match_prefix_set
+    statement.actions.bgp_actions.set_local_pref = 1000
+    set_community = statement.actions.bgp_actions.SetCommunity()
+    set_community.community_set_ref = "COMMUNITY-SET2"
+    statement.actions.bgp_actions.set_community = set_community
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject route"
+    statement.actions.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    crud.create(provider, routing_policy)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-26-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-26-ydk.txt
@@ -1,0 +1,21 @@
+prefix-set PREFIX-SET1
+  10.0.0.0/16 ge 24 le 32,
+  172.0.0.0/8 ge 16 le 32
+end-set
+!
+community-set COMMUNITY-SET2
+  65172:17001
+end-set
+!
+route-policy POLICY3
+  #statement-name prefix-set1
+  if destination in PREFIX-SET1 then
+    set local-preference 1000
+    set community COMMUNITY-SET2
+    done
+  endif
+  #statement-name reject
+  drop
+end-policy
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-28-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-28-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-routing-policy.
+
+usage: nc-create-config-routing-policy-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.models.bgp import bgp_policy as oc_bgp_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY4"
+    statement = policy_definition.statements.Statement()
+    statement.name = "next-hop-self"
+    set_next_hop = oc_bgp_policy.BgpNextHopTypeEnum.SELF
+    statement.actions.bgp_actions.set_next_hop = set_next_hop
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    crud.create(provider, routing_policy)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-28-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-routing-policy-28-ydk.txt
@@ -1,0 +1,7 @@
+route-policy POLICY4
+  #statement-name next-hop-self
+  set next-hop self
+  done
+end-policy
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-10-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-routing-policy.
+
+usage: nc-delete-config-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    # crud.delete(provider, routing_policy)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-20-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-20-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-routing-policy.
+
+usage: nc-delete-config-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    crud.delete(provider, routing_policy)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-20-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-delete-config-routing-policy-20-ydk.txt
@@ -1,0 +1,10 @@
+no prefix-set PREFIX-SET1
+no as-path-set AS-PATH-SET1
+no community-set COMMUNITY-SET1
+no community-set COMMUNITY-SET2
+no route-policy POLICY1
+no route-policy POLICY2
+no route-policy POLICY3
+no route-policy POLICY4
+end
+

--- a/samples/basic/ydk/models/openconfig/nc-read-config-routing-policy-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-read-config-routing-policy-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model openconfig-routing-policy.
+
+usage: nc-read-config-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+import logging
+
+
+def process_routing_policy(routing_policy):
+    """Process data in routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    # routing_policy = crud.read(provider, routing_policy)  # read object from NETCONF device
+    process_routing_policy(routing_policy)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-update-config-routing-policy-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-update-config-routing-policy-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update config for model openconfig-routing-policy.
+
+usage: nc-update-config-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # crud.update(provider, routing_policy)  # update object on NETCONF device
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Sample apps include four boilerplate apps for CRUD operations, plus five
custom apps to create and delete routing policies using the openconfig
model (openconfig-routing-policy):
nc-create-config-routing-policy-22-ydk.py - accept all routes
nc-create-config-routing-policy-24-ydk.py - AS path, community, local p.
nc-create-config-routing-policy-26-ydk.py - prefix, community, local p.
nc-create-config-routing-policy-28-ydk.py - next-hop self
nc-delete-config-routing-policy-20-ydk.py - delete routing policies
