### PR TITLE
Add new configuration apps for OpenConfig BGP

### DIFF
--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-41-ydk.py
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-41-ydk.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-bgp.
+
+usage: nc-create-config-bgp-41-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.bgp import bgp as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = oc_bgp.Bgp()  # create config object
+    config_bgp(bgp)  # add object configuration
+
+    crud.create(provider, bgp)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-41-ydk.txt
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-41-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv6 unicast
+  !
+ !
+ neighbor 2001:db8::ff:2
+  use neighbor-group IBGP
+ !
+!
+end
+

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-42-ydk.py
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-42-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-bgp.
+
+usage: nc-create-config-bgp-42-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.bgp import bgp as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.export_policy.append("POLICY2")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "172.16.255.2"
+    neighbor.config.neighbor_address = "172.16.255.2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = oc_bgp.Bgp()  # create config object
+    config_bgp(bgp)  # add object configuration
+
+    crud.create(provider, bgp)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-42-ydk.txt
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-42-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv4 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv4 unicast
+   route-policy POLICY2 out
+  !
+ !
+ neighbor 172.16.255.2
+  use neighbor-group IBGP
+ !
+!
+end

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-43-ydk.py
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-43-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-bgp.
+
+usage: nc-create-config-bgp-43-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.bgp import bgp as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.export_policy.append("POLICY2")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = oc_bgp.Bgp()  # create config object
+    config_bgp(bgp)  # add object configuration
+
+    crud.create(provider, bgp)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-43-ydk.txt
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-43-ydk.txt
@@ -1,0 +1,16 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv6 unicast
+   route-policy POLICY2 out
+  !
+ !
+ neighbor 2001:db8::ff:2
+  use neighbor-group IBGP
+ !
+!
+end
+

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-44-ydk.py
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-44-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-bgp.
+
+usage: nc-create-config-bgp-44-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.bgp import bgp as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "EBGP"
+    peer_group.config.peer_group_name = "EBGP"
+    peer_group.config.peer_as = 65002
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.import_policy.append("POLICY3")
+    afi_safi.apply_policy.config.export_policy.append("POLICY1")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "192.168.1.1"
+    neighbor.config.neighbor_address = "192.168.1.1"
+    neighbor.config.peer_group = "EBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = oc_bgp.Bgp()  # create config object
+    config_bgp(bgp)  # add object configuration
+
+    crud.create(provider, bgp)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-44-ydk.txt
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-44-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv4 unicast
+ !
+ neighbor-group EBGP
+  remote-as 65002
+  address-family ipv4 unicast
+   route-policy POLICY3 in
+   route-policy POLICY1 out
+  !
+ !
+ neighbor 192.168.1.1
+  use neighbor-group EBGP
+ !
+!
+end

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-45-ydk.py
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-45-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-bgp.
+
+usage: nc-create-config-bgp-45-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.bgp import bgp as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "EBGP"
+    peer_group.config.peer_group_name = "EBGP"
+    peer_group.config.peer_as = 65002
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.import_policy.append("POLICY3")
+    afi_safi.apply_policy.config.export_policy.append("POLICY1")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8:e:1::1"
+    neighbor.config.neighbor_address = "2001:db8:e:1::1"
+    neighbor.config.peer_group = "EBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = oc_bgp.Bgp()  # create config object
+    config_bgp(bgp)  # add object configuration
+
+    crud.create(provider, bgp)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/bgp/nc-create-config-bgp-45-ydk.txt
+++ b/samples/basic/ydk/models/bgp/nc-create-config-bgp-45-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group EBGP
+  remote-as 65002
+  address-family ipv6 unicast
+   route-policy POLICY3 in
+   route-policy POLICY1 out
+  !
+ !
+ neighbor 2001:db8:e:1::1
+  use neighbor-group EBGP
+ !
+!
+end


### PR DESCRIPTION
Five custom apps for IPv4/IPv6 BGP configuration using OpenConfig
(openconfig-bgp):
nc-create-config-bgp-41-ydk.py - IPv6 iBGP neighbor group w/o policy
nc-create-config-bgp-42-ydk.py - IPv4 iBGP neighbor group w/ policy
nc-create-config-bgp-43-ydk.py - IPv6 iBGP neighbor group w/ policy
nc-create-config-bgp-44-ydk.py - IPv4 eBGP neighbor group w/ policy
nc-create-config-bgp-45-ydk.py - IPv6 eBGP neighbor group w/ policy
