### PR TITLE
Add sample apps for OpenConfig MPLS

### DIFF
--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    # crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-20-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-20-ydk.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # signaling protocols interface gi0/0/0/0
+    rsvp_te = mpls.signaling_protocols.rsvp_te
+    interface = rsvp_te.interface_attributes.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/0"
+    interface.config.interface_name = "GigabitEthernet0/0/0/0"
+    interface.subscription.config.subscription = 100
+    rsvp_te.interface_attributes.interface.append(interface)
+
+    # signaling protocols interface gi0/0/0/1
+    interface = rsvp_te.interface_attributes.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/1"
+    interface.config.interface_name = "GigabitEthernet0/0/0/1"
+    interface.subscription.config.subscription = 100
+    rsvp_te.interface_attributes.interface.append(interface)
+
+    mpls.signaling_protocols.rsvp_te = rsvp_te
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-20-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-20-ydk.txt
@@ -1,0 +1,11 @@
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth percentage 100
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth percentage 100
+ !
+!
+mpls traffic-eng
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-30-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-30-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # LSP timers
+    mpls.te_global_attributes.te_lsp_timers.config.cleanup_delay = 20
+    mpls.te_global_attributes.te_lsp_timers.config.install_delay = 20
+    mpls.te_global_attributes.te_lsp_timers.config.reoptimize_timer = 3600
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-30-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-30-ydk.txt
@@ -1,0 +1,6 @@
+mpls traffic-eng
+ reoptimize 3600
+ reoptimize timers delay cleanup 20
+ reoptimize timers delay installation 20
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-32-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-32-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # interface attributes gi0/0/0/0
+    interface = mpls.te_interface_attributes.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.config.name = "GigabitEthernet0/0/0/0"
+    mpls.te_interface_attributes.interface.append(interface)
+
+    # interface attributes gi0/0/0/1
+    interface = mpls.te_interface_attributes.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.config.name = "GigabitEthernet0/0/0/1"
+    mpls.te_interface_attributes.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-32-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-32-ydk.txt
@@ -1,0 +1,13 @@
+srlg
+ interface GigabitEthernet0/0/0/0
+ !
+ interface GigabitEthernet0/0/0/1
+ !
+!
+mpls traffic-eng
+ interface GigabitEthernet0/0/0/0
+ !
+ interface GigabitEthernet0/0/0/1
+ !
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-34-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-34-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # interface attributes gi0/0/0/0
+    interface = mpls.te_interface_attributes.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.config.name = "GigabitEthernet0/0/0/1"
+    interface.config.admin_group.append("RED")
+    interface.config.admin_group.append("BLUE")
+    mpls.te_interface_attributes.interface.append(interface)
+
+    # TE global attributes
+    admin_group = mpls.te_global_attributes.mpls_admin_groups.AdminGroup()
+    admin_group.admin_group_name = "RED"
+    admin_group.config.admin_group_name = "RED"
+    admin_group.config.bit_position = 0
+    mpls.te_global_attributes.mpls_admin_groups.admin_group.append(admin_group)
+    admin_group = mpls.te_global_attributes.mpls_admin_groups.AdminGroup()
+    admin_group.admin_group_name = "BLUE"
+    admin_group.config.admin_group_name = "BLUE"
+    admin_group.config.bit_position = 1
+    mpls.te_global_attributes.mpls_admin_groups.admin_group.append(admin_group)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-34-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-34-ydk.txt
@@ -1,0 +1,12 @@
+srlg
+ interface GigabitEthernet0/0/0/1
+ !
+!
+mpls traffic-eng
+ interface GigabitEthernet0/0/0/1
+  attribute-names RED BLUE
+ !
+ affinity-map RED bit-position 0
+ affinity-map BLUE bit-position 1
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-delete-config-mpls-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-delete-config-mpls-10-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-mpls.
+
+usage: nc-delete-config-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    # crud.delete(provider, mpls)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-delete-config-mpls-30-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-delete-config-mpls-30-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-mpls.
+
+usage: nc-delete-config-mpls-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    crud.delete(provider, mpls)  # delete object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-read-config-mpls-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-read-config-mpls-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model openconfig-mpls.
+
+usage: nc-read-config-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def process_mpls(mpls):
+    """Process data in mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    # mpls = crud.read(provider, mpls)  # read object from NETCONF device
+    process_mpls(mpls)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-update-config-mpls-10-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-update-config-mpls-10-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update config for model openconfig-mpls.
+
+usage: nc-update-config-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    # crud.update(provider, mpls)  # update object on NETCONF device
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Sample apps include four boilerplate apps for CRUD operations, plus five
custom apps to create and delete MPLS traffic configuration on a router
using the openconfig MPLS model (openconfig-mpls):
nc-create-config-mpls-20-ydk.py - Enable RSVP-TE on interfaces
nc-create-config-mpls-30-ydk.py - Set MPLS-TE timers
nc-create-config-mpls-32-ydk.py - Enable MPLS-TE on interfaces
nc-create-config-mpls-34-ydk.py - Set affinities (admin groups)
nc-delete-config-mpls-30-ydk.py - Delete RSVP-TE/MPLS-TE config
