### PR TITLE
Add apps for OpenConfig TE tunnel and path config

### DIFF
--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-40-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-40-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # constrained path
+    named_explicit_paths = mpls.lsps.constrained_path.NamedExplicitPaths()
+    named_explicit_paths.name = "LER1-LSR1-LER2"
+    named_explicit_paths.config.name = "LER1-LSR1-LER2"
+
+    # strict hop
+    explicit_route_objects = named_explicit_paths.ExplicitRouteObjects()
+    explicit_route_objects.index = 10
+    explicit_route_objects.config.index = 10
+    explicit_route_objects.config.address = "172.16.1.1"
+    explicit_route_objects.config.hop_type = oc_mpls.MplsHopTypeEnum.STRICT
+    named_explicit_paths.explicit_route_objects.append(explicit_route_objects)
+
+    # strict hop
+    explicit_route_objects = named_explicit_paths.ExplicitRouteObjects()
+    explicit_route_objects.index = 20
+    explicit_route_objects.config.index = 20
+    explicit_route_objects.config.address = "172.16.1.5"
+    explicit_route_objects.config.hop_type = oc_mpls.MplsHopTypeEnum.STRICT
+    named_explicit_paths.explicit_route_objects.append(explicit_route_objects)
+
+    mpls.lsps.constrained_path.named_explicit_paths.append(named_explicit_paths)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-40-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-40-ydk.txt
@@ -1,0 +1,8 @@
+explicit-path name LER1-LSR1-LER2
+ index 10 next-address strict ipv4 unicast 172.16.1.1
+ index 20 next-address strict ipv4 unicast 172.16.1.5
+!
+mpls traffic-eng
+!
+end
+

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-50-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-50-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-50-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+from ydk.models.openconfig import openconfig_mpls_types as oc_mpls_types
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # tunnel
+    tunnel = mpls.lsps.constrained_path.Tunnel()
+    tunnel.name = "LER1-LER2-t10"
+    tunnel.config.name = "LER1-LER2-t10"
+    tunnel.config.type = oc_mpls_types.P2P_Identity()
+    tunnel.type = oc_mpls_types.P2P_Identity()
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "DYNAMIC"
+    p2p_primary_paths.config.name = "DYNAMIC"
+    p2p_primary_paths.config.preference = 10
+    path_computation_method = oc_mpls.LocallyComputed_Identity()
+    p2p_primary_paths.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    mpls.lsps.constrained_path.tunnel.append(tunnel)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-50-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-50-ydk.txt
@@ -1,0 +1,13 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t10
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+  !
+ !
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-52-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-52-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-52-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # tunnel
+    tunnel = mpls.lsps.constrained_path.Tunnel()
+    tunnel.name = "LER1-LER2-t20"
+    tunnel.config.name = "LER1-LER2-t20"
+    # tunnel.config.type =  ## identity
+    # tunnel.type =  ## identity
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "DYNAMIC"
+    p2p_primary_paths.config.name = "DYNAMIC"
+    p2p_primary_paths.config.preference = 10
+    # p2p_primary_paths.config.path_computation_method =   ## identity
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    # auto-bandwidth configuration
+    tunnel.bandwidth.auto_bandwidth.config.enabled = True
+    tunnel.bandwidth.auto_bandwidth.config.min_bw = 10000
+    tunnel.bandwidth.auto_bandwidth.config.max_bw = 500000
+    tunnel.bandwidth.auto_bandwidth.overflow.config.overflow_threshold = 15
+    tunnel.bandwidth.auto_bandwidth.overflow.config.trigger_event_count = 3
+    tunnel.bandwidth.auto_bandwidth.underflow.config.underflow_threshold = 15
+    tunnel.bandwidth.auto_bandwidth.underflow.config.trigger_event_count = 3
+
+    mpls.lsps.constrained_path.tunnel.append(tunnel)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-52-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-52-ydk.txt
@@ -1,0 +1,18 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t20
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   auto-bw
+    bw-limit min 10000 max 500000
+    overflow threshold 15 min 10 limit 3
+    adjustment-threshold 5 min 10
+    underflow threshold 15 min 10 limit 3
+   !      
+   destination 172.16.255.2
+  !
+ !
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-54-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-54-ydk.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-54-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # tunnel
+    tunnel = mpls.lsps.constrained_path.Tunnel()
+    tunnel.name = "LER1-LER2-t30"
+    tunnel.config.name = "LER1-LER2-t30"
+    # tunnel.config.type =  ## identity
+    # tunnel.config.protection_style_requested =  ## identity
+    # tunnel.type =  ## identity
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "DYNAMIC"
+    p2p_primary_paths.config.name = "DYNAMIC"
+    p2p_primary_paths.config.preference = 10
+    # p2p_primary_paths.config.path_computation_method =   ## identity
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    mpls.lsps.constrained_path.tunnel.append(tunnel)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-54-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-54-ydk.txt
@@ -1,0 +1,14 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t30
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+   fast-reroute
+  !
+ !
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-56-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-56-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-56-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # tunnel
+    tunnel = mpls.lsps.constrained_path.Tunnel()
+    tunnel.name = "LER1-LER2-t40"
+    tunnel.config.name = "LER1-LER2-t40"
+    # tunnel.type =  ## identity
+    tunnel.config.setup_priority = 5
+    tunnel.config.hold_priority = 5
+    # tunnel.config.type =  ## identity
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "DYNAMIC"
+    p2p_primary_paths.config.name = "DYNAMIC"
+    p2p_primary_paths.config.preference = 10
+    # p2p_primary_paths.config.path_computation_method =   ## identity
+    p2p_primary_paths.admin_groups.config.exclude_group.append("RED")
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    mpls.lsps.constrained_path.tunnel.append(tunnel)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-56-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-56-ydk.txt
@@ -1,0 +1,15 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t40
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   priority 5 5
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+   affinity exclude RED
+  !
+ !
+!
+end

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-58-ydk.py
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-58-ydk.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create config for model openconfig-mpls.
+
+usage: nc-create-config-mpls-58-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_mpls as oc_mpls
+import logging
+
+
+def config_mpls(mpls):
+    """Add config data to mpls object."""
+    # tunnel
+    tunnel = mpls.lsps.constrained_path.Tunnel()
+    tunnel.name = "LER1-LER2-t50"
+    tunnel.config.name = "LER1-LER2-t50"
+    # tunnel.type =  ## identity
+    # tunnel.config.type =  ## identity
+    # explicit path
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "LER1-LSR1-LER2"
+    p2p_primary_paths.config.name = "LER1-LSR1-LER2"
+    p2p_primary_paths.config.preference = 10
+    # p2p_primary_paths.config.path_computation_method =   ## identity
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    # dynamic path
+    p2p_primary_paths = tunnel.p2p_tunnel_attributes.P2PPrimaryPaths()
+    p2p_primary_paths.name = "DYNAMIC"
+    p2p_primary_paths.config.name = "DYNAMIC"
+    p2p_primary_paths.config.preference = 20
+    # p2p_primary_paths.config.path_computation_method =   ## identity
+    tunnel.p2p_tunnel_attributes.p2p_primary_paths.append(p2p_primary_paths)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    mpls.lsps.constrained_path.tunnel.append(tunnel)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls = oc_mpls.Mpls()  # create config object
+    config_mpls(mpls)  # add object configuration
+
+    crud.create(provider, mpls)  # create object on NETCONF device
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/ydk/models/openconfig/nc-create-config-mpls-58-ydk.txt
+++ b/samples/basic/ydk/models/openconfig/nc-create-config-mpls-58-ydk.txt
@@ -1,0 +1,17 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t50
+   path-option DYNAMIC
+    preference 20
+    computation dynamic
+   !
+   path-option LER1-LSR1-LER2
+    preference 10
+    computation explicit LER1-LSR1-LER2
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+  !
+ !
+!
+end


### PR DESCRIPTION
Six custom apps to configure TE tunnels and paths using OpenConfig model
(openconfig-mpls).  Apps assume that the router is already configured
for MPLS traffic engineering.  Samples includes different types of tunnels:
nc-create-config-mpls-40-ydk.py - explicit path
nc-create-config-mpls-50-ydk.py - dynamic-path tunnel
nc-create-config-mpls-52-ydk.py - auto-bw tunnel
nc-create-config-mpls-54-ydk.py - protected tunnel
nc-create-config-mpls-56-ydk.py - tunnel prio/admin-group
nc-create-config-mpls-58-ydk.py - tunnel with path options
