### PR TITLE
Add sample apps for encoding routing policies

### DIFF
--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-10-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-20-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-20-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg \
+    as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    route_policy_name = "PASS-ALL"
+    rpl_route_policy = """
+        route-policy PASS-ALL
+          #statement-name pass-all
+          pass
+        end-policy
+        """
+    # configure RPL policy
+    route_policy = routing_policy.route_policies.RoutePolicy()
+    route_policy.route_policy_name = route_policy_name
+    route_policy.rpl_route_policy = rpl_route_policy
+    routing_policy.route_policies.route_policy.append(route_policy)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-20-ydk.xml
@@ -1,0 +1,14 @@
+<routing-policy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg">
+  <route-policies>
+    <route-policy>
+      <route-policy-name>PASS-ALL</route-policy-name>
+      <rpl-route-policy>
+        route-policy PASS-ALL
+          #statement-name pass-all
+          pass
+        end-policy
+        </rpl-route-policy>
+    </route-policy>
+  </route-policies>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-22-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-22-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg \
+    as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    route_policy_name = "POLICY1"
+    rpl_route_policy = """
+        route-policy POLICY1
+          #statement-name accept route
+          done
+        end-policy
+        """
+    # configure RPL policy
+    route_policy = routing_policy.route_policies.RoutePolicy()
+    route_policy.route_policy_name = route_policy_name
+    route_policy.rpl_route_policy = rpl_route_policy
+    routing_policy.route_policies.route_policy.append(route_policy)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-22-ydk.xml
@@ -1,0 +1,14 @@
+<routing-policy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg">
+  <route-policies>
+    <route-policy>
+      <route-policy-name>POLICY1</route-policy-name>
+      <rpl-route-policy>
+        route-policy POLICY1
+          #statement-name accept route
+          done
+        end-policy
+        </rpl-route-policy>
+    </route-policy>
+  </route-policies>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-24-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-24-ydk.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg \
+    as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    community_set_name = "COMMUNITY-SET1"
+    rpl_community_set = """
+        community-set COMMUNITY-SET1
+          ios-regex '^65172:17...$',
+          65172:16001
+        end-set
+        """
+    as_path_set_name = "AS-PATH-SET1"
+    rplas_path_set = """
+        as-path-set AS-PATH-SET1
+          ios-regex '^65172'
+        end-set
+        """
+    route_policy_name = "POLICY2"
+    rpl_route_policy = """
+        route-policy POLICY2
+          #statement-name community-set1
+          if community matches-every COMMUNITY-SET1 then
+            done
+          endif
+          #statement-name as-path-set1
+          if as-path in AS-PATH-SET1 then
+            set local-preference 50
+            done
+          endif
+          #statement-name reject route
+          drop
+        end-policy
+        """
+    # configure community set
+    community_set = routing_policy.sets.community_sets.CommunitySet()
+    community_set.set_name = community_set_name
+    community_set.rpl_community_set = rpl_community_set
+    routing_policy.sets.community_sets.community_set.append(community_set)
+
+    # configure as-path set
+    as_path_set = routing_policy.sets.as_path_sets.AsPathSet()
+    as_path_set.set_name = as_path_set_name
+    as_path_set.rplas_path_set = rplas_path_set
+    routing_policy.sets.as_path_sets.as_path_set.append(as_path_set)
+
+    # configure RPL policy
+    route_policy = routing_policy.route_policies.RoutePolicy()
+    route_policy.route_policy_name = route_policy_name
+    route_policy.rpl_route_policy = rpl_route_policy
+    routing_policy.route_policies.route_policy.append(route_policy)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-24-ydk.xml
@@ -1,0 +1,46 @@
+<routing-policy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg">
+  <route-policies>
+    <route-policy>
+      <route-policy-name>POLICY2</route-policy-name>
+      <rpl-route-policy>
+        route-policy POLICY2
+          #statement-name community-set1
+          if community matches-every COMMUNITY-SET1 then
+            done
+          endif
+          #statement-name as-path-set1
+          if as-path in AS-PATH-SET1 then
+            set local-preference 50
+            done
+          endif
+          #statement-name reject route
+          drop
+        end-policy
+        </rpl-route-policy>
+    </route-policy>
+  </route-policies>
+  <sets>
+    <as-path-sets>
+      <as-path-set>
+        <set-name>AS-PATH-SET1</set-name>
+        <rplas-path-set>
+        as-path-set AS-PATH-SET1
+          ios-regex '^65172'
+        end-set
+        </rplas-path-set>
+      </as-path-set>
+    </as-path-sets>
+    <community-sets>
+      <community-set>
+        <set-name>COMMUNITY-SET1</set-name>
+        <rpl-community-set>
+        community-set COMMUNITY-SET1
+          ios-regex '^65172:17...$',
+          65172:16001
+        end-set
+        </rpl-community-set>
+      </community-set>
+    </community-sets>
+  </sets>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-26-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-26-ydk.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    set_name = "PREFIX-SET1"
+    rpl_prefix_set = """
+        prefix-set PREFIX-SET1
+          10.0.0.0/16 ge 24 le 32,
+          172.0.0.0/8 ge 16 le 32
+        end-set
+        """
+    community_set_name = "COMMUNITY-SET2"
+    rpl_community_set = """
+        community-set COMMUNITY-SET2
+          65172:17001
+        end-set
+        """
+    route_policy_name = "POLICY3"
+    rpl_route_policy = """
+        route-policy POLICY3
+          #statement-name prefix-set1
+          if destination in PREFIX-SET1 then
+            set local-preference 1000
+            set community COMMUNITY-SET2
+            done
+          endif
+          #statement-name reject
+          drop
+        end-policy
+        """
+    # configure prefix set
+    prefix_set = routing_policy.sets.prefix_sets.PrefixSet()
+    prefix_set.set_name = set_name
+    prefix_set.rpl_prefix_set = rpl_prefix_set
+    routing_policy.sets.prefix_sets.prefix_set.append(prefix_set)
+
+    # configure community set
+    community_set = routing_policy.sets.community_sets.CommunitySet()
+    community_set.set_name = community_set_name
+    community_set.rpl_community_set = rpl_community_set
+    routing_policy.sets.community_sets.community_set.append(community_set)
+
+    # configure RPL policy
+    route_policy = routing_policy.route_policies.RoutePolicy()
+    route_policy.route_policy_name = route_policy_name
+    route_policy.rpl_route_policy = rpl_route_policy
+    routing_policy.route_policies.route_policy.append(route_policy)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-26-ydk.xml
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-26-ydk.xml
@@ -1,0 +1,43 @@
+<routing-policy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg">
+  <route-policies>
+    <route-policy>
+      <route-policy-name>POLICY3</route-policy-name>
+      <rpl-route-policy>
+        route-policy POLICY3
+          #statement-name prefix-set1
+          if destination in PREFIX-SET1 then
+            set local-preference 1000
+            set community COMMUNITY-SET2
+            done
+          endif
+          #statement-name reject
+          drop
+        end-policy
+        </rpl-route-policy>
+    </route-policy>
+  </route-policies>
+  <sets>
+    <community-sets>
+      <community-set>
+        <set-name>COMMUNITY-SET2</set-name>
+        <rpl-community-set>
+        community-set COMMUNITY-SET2
+          65172:17001
+        end-set
+        </rpl-community-set>
+      </community-set>
+    </community-sets>
+    <prefix-sets>
+      <prefix-set>
+        <set-name>PREFIX-SET1</set-name>
+        <rpl-prefix-set>
+        prefix-set PREFIX-SET1
+          10.0.0.0/16 ge 24 le 32,
+          172.0.0.0/8 ge 16 le 32
+        end-set
+        </rpl-prefix-set>
+      </prefix-set>
+    </prefix-sets>
+  </sets>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-28-ydk.py
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-28-ydk.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-policy-repository-cfg.
+
+usage: cd-encode-config-policy-repository-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.policy import Cisco_IOS_XR_policy_repository_cfg \
+    as xr_policy_repository_cfg
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    route_policy_name = "POLICY4"
+    rpl_route_policy = """
+        route-policy POLICY4
+          #statement-name next-hop-self
+          set next-hop self
+          done
+        end-policy
+        """
+    # configure RPL policy
+    route_policy = routing_policy.route_policies.RoutePolicy()
+    route_policy.route_policy_name = route_policy_name
+    route_policy.rpl_route_policy = rpl_route_policy
+    routing_policy.route_policies.route_policy.append(route_policy)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = xr_policy_repository_cfg.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-28-ydk.xml
+++ b/samples/basic/codec/ydk/models/policy/cd-encode-config-policy-repository-28-ydk.xml
@@ -1,0 +1,15 @@
+<routing-policy xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg">
+  <route-policies>
+    <route-policy>
+      <route-policy-name>POLICY4</route-policy-name>
+      <rpl-route-policy>
+        route-policy POLICY4
+          #statement-name next-hop-self
+          set next-hop self
+          done
+        end-policy
+        </rpl-route-policy>
+    </route-policy>
+  </route-policies>
+</routing-policy>
+


### PR DESCRIPTION
Includes a bilerplate app and four customer apps for performing XML
encoding of configuration:
cd-encode-config-policy-repository-20-ydk.py - pass all
cd-encode-config-policy-repository-22-ydk.py - done
cd-encode-config-policy-repository-24-ydk.py - AS Path
cd-encode-config-policy-repository-26-ydk.py - local pref, community
cd-encode-config-policy-repository-28-ydk.py - next-hop-self
