### PR TITLE
Add sample apps for encoding global intf config

### DIFF
--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-10-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_global_interface_configuration(global_interface_configuration):
+    """Add config data to global_interface_configuration object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    global_interface_configuration = xr_ifmgr_cfg.GlobalInterfaceConfiguration()  # create config object
+    config_global_interface_configuration(global_interface_configuration)  # add object configuration
+
+    # print(codec.encode(provider, global_interface_configuration))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-20-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-20-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_global_interface_configuration(global_interface_configuration):
+    """Add config data to global_interface_configuration object."""
+    # display link status messages for physical links
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DEFAULT
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    global_interface_configuration = xr_ifmgr_cfg.GlobalInterfaceConfiguration()
+    # add object configuration
+    config_global_interface_configuration(global_interface_configuration)
+
+    # encode and print object
+    print(codec.encode(provider, global_interface_configuration))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-20-ydk.xml
@@ -1,0 +1,4 @@
+<global-interface-configuration xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <link-status>default</link-status>
+</global-interface-configuration>
+

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-22-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-22-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_global_interface_configuration(global_interface_configuration):
+    """Add config data to global_interface_configuration object."""
+    # disable link status messages
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DISABLE
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    global_interface_configuration = xr_ifmgr_cfg.GlobalInterfaceConfiguration()
+    # add object configuration
+    config_global_interface_configuration(global_interface_configuration)
+
+    # encode and print object
+    print(codec.encode(provider, global_interface_configuration))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-22-ydk.xml
@@ -1,0 +1,4 @@
+<global-interface-configuration xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <link-status>disable</link-status>
+</global-interface-configuration>
+

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-24-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-24-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_global_interface_configuration(global_interface_configuration):
+    """Add config data to global_interface_configuration object."""
+    # display link status messages for all interfaces
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.SOFTWARE_INTERFACES
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    global_interface_configuration = xr_ifmgr_cfg.GlobalInterfaceConfiguration()
+    # add object configuration
+    config_global_interface_configuration(global_interface_configuration)
+
+    # encode and print object
+    print(codec.encode(provider, global_interface_configuration))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-24-ydk.xml
@@ -1,0 +1,4 @@
+<global-interface-configuration xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <link-status>software-interfaces</link-status>
+</global-interface-configuration>
+


### PR DESCRIPTION
Includes a bilerplate app and three custom apps for performing XML
encoding of configuration:
cd-encode-config-ifmgr-20-ydk.py - default message behavior
cd-encode-config-ifmgr-22-ydk.py - disable link messages
cd-encode-config-ifmgr-24-ydk.py - link messages for logical interfaces
