### PR TITLE
Add sample apps for encoding interface config

### DIFF
--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-11-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-11-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-11-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()  # create config object
+    config_interface_configurations(interface_configurations)  # add object configuration
+
+    # print(codec.encode(provider, interface_configurations))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-30-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-30-ydk.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-30-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv4 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "Loopback0"
+    interface_configuration.interface_virtual = Empty()
+    interface_configuration.description = "PRIMARY ROUTER LOOPBACK"
+    primary = interface_configuration.ipv4_network.addresses.Primary()
+    primary.address = "172.16.255.1"
+    primary.netmask = "255.255.255.255"
+    interface_configuration.ipv4_network.addresses.primary = primary
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    # encode and print object
+    print(codec.encode(provider, interface_configurations))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-30-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-30-ydk.xml
@@ -1,0 +1,17 @@
+<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <interface-configuration>
+    <active>act</active>
+    <interface-name>Loopback0</interface-name>
+    <description>PRIMARY ROUTER LOOPBACK</description>
+    <interface-virtual></interface-virtual>
+    <ipv4-network xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-io-cfg">
+      <addresses>
+        <primary>
+          <address>172.16.255.1</address>
+          <netmask>255.255.255.255</netmask>
+        </primary>
+      </addresses>
+    </ipv4-network>
+  </interface-configuration>
+</interface-configurations>
+

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-32-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-32-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-32-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv6 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "Loopback0"
+    interface_configuration.interface_virtual = Empty()
+    interface_configuration.description = "PRIMARY ROUTER LOOPBACK"
+    addresses = interface_configuration.ipv6_network.addresses
+    regular_address = addresses.regular_addresses.RegularAddress()
+    regular_address.address = "2001:db8::ff:1"
+    regular_address.prefix_length = 128
+    addresses.regular_addresses.regular_address.append(regular_address)
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    # encode and print object
+    print(codec.encode(provider, interface_configurations))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-32-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-32-ydk.xml
@@ -1,0 +1,19 @@
+<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <interface-configuration>
+    <active>act</active>
+    <interface-name>Loopback0</interface-name>
+    <description>PRIMARY ROUTER LOOPBACK</description>
+    <interface-virtual></interface-virtual>
+    <ipv6-network xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-cfg">
+      <addresses>
+        <regular-addresses>
+          <regular-address>
+            <address>2001:db8::ff:1</address>
+            <prefix-length>128</prefix-length>
+          </regular-address>
+        </regular-addresses>
+      </addresses>
+    </ipv6-network>
+  </interface-configuration>
+</interface-configurations>
+

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-34-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-34-ydk.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-34-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv4 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "GigabitEthernet0/0/0/0"
+    interface_configuration.description = "CONNECTS TO LSR1 (g0/0/0/1)"
+    mtu = interface_configuration.mtus.Mtu()
+    mtu.owner = "GigabitEthernet"
+    mtu.mtu = 9192
+    interface_configuration.mtus.mtu.append(mtu)
+    primary = interface_configuration.ipv4_network.addresses.Primary()
+    primary.address = "172.16.1.0"
+    primary.netmask = "255.255.255.254"
+    interface_configuration.ipv4_network.addresses.primary = primary
+    interface_configuration.statistics.load_interval = 30
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    # encode and print object
+    print(codec.encode(provider, interface_configurations))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-34-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-34-ydk.xml
@@ -1,0 +1,25 @@
+<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <interface-configuration>
+    <active>act</active>
+    <interface-name>GigabitEthernet0/0/0/0</interface-name>
+    <description>CONNECTS TO LSR1 (g0/0/0/1)</description>
+    <ipv4-network xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-io-cfg">
+      <addresses>
+        <primary>
+          <address>172.16.1.0</address>
+          <netmask>255.255.255.254</netmask>
+        </primary>
+      </addresses>
+    </ipv4-network>
+    <mtus>
+      <mtu>
+        <owner>GigabitEthernet</owner>
+        <mtu>9192</mtu>
+      </mtu>
+    </mtus>
+    <statistics xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-statsd-cfg">
+      <load-interval>30</load-interval>
+    </statistics>
+  </interface-configuration>
+</interface-configurations>
+

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-36-ydk.py
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-36-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ifmgr-cfg.
+
+usage: cd-encode-config-ifmgr-36-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ifmgr import Cisco_IOS_XR_ifmgr_cfg as xr_ifmgr_cfg
+import logging
+
+
+def config_interface_configurations(interface_configurations):
+    """Add config data to interface_configurations object."""
+    # configure IPv6 loopback
+    interface_configuration = interface_configurations.InterfaceConfiguration()
+    interface_configuration.active = "act"
+    interface_configuration.interface_name = "GigabitEthernet0/0/0/0"
+    interface_configuration.description = "CONNECTS TO LSR1 (g0/0/0/1)"
+    mtu = interface_configuration.mtus.Mtu()
+    mtu.owner = "GigabitEthernet"
+    mtu.mtu = 9192
+    interface_configuration.mtus.mtu.append(mtu)
+    addresses = interface_configuration.ipv6_network.addresses
+    regular_address = addresses.regular_addresses.RegularAddress()
+    regular_address.address = "2001:db8::1:0"
+    regular_address.prefix_length = 127
+    addresses.regular_addresses.regular_address.append(regular_address)
+    interface_configuration.statistics.load_interval = 30
+    interface_configurations.interface_configuration.append(interface_configuration)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    # create config object
+    interface_configurations = xr_ifmgr_cfg.InterfaceConfigurations()
+    # add object configuration
+    config_interface_configurations(interface_configurations)
+
+    # encode and print object
+    print(codec.encode(provider, interface_configurations))
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-36-ydk.xml
+++ b/samples/basic/codec/ydk/models/ifmgr/cd-encode-config-ifmgr-36-ydk.xml
@@ -1,0 +1,27 @@
+<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+  <interface-configuration>
+    <active>act</active>
+    <interface-name>GigabitEthernet0/0/0/0</interface-name>
+    <description>CONNECTS TO LSR1 (g0/0/0/1)</description>
+    <ipv6-network xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-cfg">
+      <addresses>
+        <regular-addresses>
+          <regular-address>
+            <address>2001:db8::1:0</address>
+            <prefix-length>127</prefix-length>
+          </regular-address>
+        </regular-addresses>
+      </addresses>
+    </ipv6-network>
+    <mtus>
+      <mtu>
+        <owner>GigabitEthernet</owner>
+        <mtu>9192</mtu>
+      </mtu>
+    </mtus>
+    <statistics xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-statsd-cfg">
+      <load-interval>30</load-interval>
+    </statistics>
+  </interface-configuration>
+</interface-configurations>
+


### PR DESCRIPTION
Includes a boilerplat app and four custom apps for performing XML
encoding of interface configuration:
cd-encode-config-ifmgr-30-ydk.py - virtual IPv4 intf (lo0)
cd-encode-config-ifmgr-32-ydk.py - virtual IPv6 intf (lo0)
cd-encode-config-ifmgr-34-ydk.py - physical IPv4 intf (ge0/0/0/0)
cd-encode-config-ifmgr-36-ydk.py - physical IPv6 intf (ge0/0/0/0)
