### PR TITLE
Add sample apps for encoding time zone config

### DIFF
--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-10-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    # print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-20-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-20-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "PST"
+    time_zone.area_name = "PST8PDT"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-20-ydk.xml
@@ -1,0 +1,7 @@
+<clock xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-clock-linux-cfg">
+  <time-zone>
+    <area-name>PST8PDT</area-name>
+    <time-zone-name>PST</time-zone-name>
+  </time-zone>
+</clock>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-22-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-22-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CST"
+    time_zone.area_name = "PRC"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-22-ydk.xml
@@ -1,0 +1,7 @@
+<clock xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-clock-linux-cfg">
+  <time-zone>
+    <area-name>PRC</area-name>
+    <time-zone-name>CST</time-zone-name>
+  </time-zone>
+</clock>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-24-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-24-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CET"
+    time_zone.area_name = "CET"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-24-ydk.xml
@@ -1,0 +1,7 @@
+<clock xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-clock-linux-cfg">
+  <time-zone>
+    <area-name>CET</area-name>
+    <time-zone-name>CET</time-zone-name>
+  </time-zone>
+</clock>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-26-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-26-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "BRT"
+    time_zone.area_name = "Brazil/East"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-26-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-26-ydk.xml
@@ -1,0 +1,7 @@
+<clock xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-clock-linux-cfg">
+  <time-zone>
+    <area-name>Brazil/East</area-name>
+    <time-zone-name>BRT</time-zone-name>
+  </time-zone>
+</clock>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-28-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-28-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: cd-encode-config-infra-infra-clock-linux-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import logging
+
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "WAT"
+    time_zone.area_name = "Africa/Douala"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create config object
+    config_clock(clock)  # add object configuration
+
+    print(codec.encode(provider, clock))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-28-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-clock-linux-28-ydk.xml
@@ -1,0 +1,7 @@
+<clock xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-clock-linux-cfg">
+  <time-zone>
+    <area-name>Africa/Douala</area-name>
+    <time-zone-name>WAT</time-zone-name>
+  </time-zone>
+</clock>
+


### PR DESCRIPTION
Includes a boilerplate app and five custom apps for performing XML
encoding of time zone configuration:
cd-encode-config-infra-infra-clock-linux-20-ydk.py - PST PST8PDT
cd-encode-config-infra-infra-clock-linux-22-ydk.py - CST PRC
cd-encode-config-infra-infra-clock-linux-24-ydk.py - CET CET
cd-encode-config-infra-infra-clock-linux-26-ydk.py - BRT Brazil/East
cd-encode-config-infra-infra-clock-linux-28-ydk.py - WAT Africa/Douala
