### PR TITLE
Add sample apps for encoding locale config

### DIFF
--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-10-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    # print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-20-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-20-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.US
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-20-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>us</country>
+  <language>en</language>
+</locale>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-22-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-22-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.CN
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.ZH
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-22-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>cn</country>
+  <language>zh</language>
+</locale>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-24-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-24-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.DE
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.DE
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-24-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>de</country>
+  <language>de</language>
+</locale>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-26-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-26-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.BR
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.PT
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-26-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-26-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>br</country>
+  <language>pt</language>
+</locale>
+

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-28-ydk.py
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-28-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: cd-encode-config-infra-infra-locale-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.infra import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.NG
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create config object
+    config_locale(locale)  # add object configuration
+
+    print(codec.encode(provider, locale))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-28-ydk.xml
+++ b/samples/basic/codec/ydk/models/infra/cd-encode-config-infra-infra-locale-28-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>ng</country>
+  <language>en</language>
+</locale>
+


### PR DESCRIPTION
Includes a boilerplate app and five custom apps for performing XML
encoding of locale configuration:
cd-encode-config-infra-infra-locale-20-ydk.py - en-US
cd-encode-config-infra-infra-locale-22-ydk.py - zh-CN
cd-encode-config-infra-infra-locale-24-ydk.py - de-DE
cd-encode-config-infra-infra-locale-26-ydk.py - pt-BR
cd-encode-config-infra-infra-locale-28-ydk.py - en-NG
