### PR TITLE
Add sample apps for encoding static route config

### DIFF
--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-10-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    # print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-20-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "0.0.0.0"
+    vrf_prefix.prefix_length = 0
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "172.16.1.3"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-20-ydk.xml
@@ -1,0 +1,24 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv4>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>0.0.0.0</prefix>
+              <prefix-length>0</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-next-hop-address>
+                    <next-hop-address>172.16.1.3</next-hop-address>
+                  </vrf-next-hop-next-hop-address>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv4>
+    </address-family>
+  </default-vrf>
+</router-static>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-21-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-21-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-21-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "::"
+    vrf_prefix.prefix_length = 0
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-21-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-21-ydk.xml
@@ -1,0 +1,24 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv6>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>::</prefix>
+              <prefix-length>0</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-next-hop-address>
+                    <next-hop-address>2001:db8::1:3</next-hop-address>
+                  </vrf-next-hop-next-hop-address>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv6>
+    </address-family>
+  </default-vrf>
+</router-static>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-22-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-22-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "172.16.0.0"
+    vrf_prefix.prefix_length = 16
+    vrf_next_hop_interface_name = vrf_prefix.vrf_route. \
+        vrf_next_hop_table.VrfNextHopInterfaceName()
+    vrf_next_hop_interface_name.interface_name = "Null0"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_interface_name. \
+        append(vrf_next_hop_interface_name)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-22-ydk.xml
@@ -1,0 +1,24 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv4>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>172.16.0.0</prefix>
+              <prefix-length>16</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-interface-name>
+                    <interface-name>Null0</interface-name>
+                  </vrf-next-hop-interface-name>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv4>
+    </address-family>
+  </default-vrf>
+</router-static>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-23-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-23-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-23-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_interface_name = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopInterfaceName()
+    vrf_next_hop_interface_name.interface_name = "Null0"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_interface_name. \
+        append(vrf_next_hop_interface_name)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-23-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-23-ydk.xml
@@ -1,0 +1,24 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv6>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>2001:db8:a::</prefix>
+              <prefix-length>64</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-interface-name>
+                    <interface-name>Null0</interface-name>
+                  </vrf-next-hop-interface-name>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv6>
+    </address-family>
+  </default-vrf>
+</router-static>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-24-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-24-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "172.16.0.0"
+    vrf_prefix.prefix_length = 16
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "172.16.1.3"
+    vrf_next_hop_next_hop_address.metric = 254
+    vrf_next_hop_next_hop_address.object_name = "TRACKED_OBJ"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-24-ydk.xml
@@ -1,0 +1,26 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv4>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>172.16.0.0</prefix>
+              <prefix-length>16</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-next-hop-address>
+                    <next-hop-address>172.16.1.3</next-hop-address>
+                    <metric>254</metric>
+                    <object-name>TRACKED_OBJ</object-name>
+                  </vrf-next-hop-next-hop-address>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv4>
+    </address-family>
+  </default-vrf>
+</router-static>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-25-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-25-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: cd-encode-config-ip-static-25-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_static_cfg as xr_ip_static_cfg
+import logging
+
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_next_hop_next_hop_address.metric = 254
+    vrf_next_hop_next_hop_address.object_name = "TRACKED_OBJ"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create config object
+    config_router_static(router_static)  # add object configuration
+
+    print(codec.encode(provider, router_static))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-25-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-static-25-ydk.xml
@@ -1,0 +1,26 @@
+<router-static xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg">
+  <default-vrf>
+    <address-family>
+      <vrfipv6>
+        <vrf-unicast>
+          <vrf-prefixes>
+            <vrf-prefix>
+              <prefix>2001:db8:a::</prefix>
+              <prefix-length>64</prefix-length>
+              <vrf-route>
+                <vrf-next-hop-table>
+                  <vrf-next-hop-next-hop-address>
+                    <next-hop-address>2001:db8::1:3</next-hop-address>
+                    <metric>254</metric>
+                    <object-name>TRACKED_OBJ</object-name>
+                  </vrf-next-hop-next-hop-address>
+                </vrf-next-hop-table>
+              </vrf-route>
+            </vrf-prefix>
+          </vrf-prefixes>
+        </vrf-unicast>
+      </vrfipv6>
+    </address-family>
+  </default-vrf>
+</router-static>
+


### PR DESCRIPTION
Includes a boilerplate app and six custom apps for performing XML
encoding of static route configuration IOS XR:
cd-encode-config-ip-static-20-ydk.py - route to next-hop address (IPv4)
cd-encode-config-ip-static-21-ydk.py - route to next-hop address (IPv6)
cd-encode-config-ip-static-22-ydk.py - route to Null0 (IPv4)
cd-encode-config-ip-static-23-ydk.py - route to Null0 (IPv6)
cd-encode-config-ip-static-24-ydk.py - route with attributes (IPv4)
cd-encode-config-ip-static-25-ydk.py - route with attributes (IPv6)
