### PR TITLE
Add sample apps for encoding NTP config

### DIFF
--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-20-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-20-ydk.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: cd-encode-config-ip-ntp-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_ntp_cfg as xr_ip_ntp_cfg
+import logging
+
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
+    peer_ipv4.address_ipv4 = "10.0.0.1"
+    peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
+    peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create config object
+    config_ntp(ntp)  # add object configuration
+
+    print(codec.encode(provider, ntp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-20-ydk.xml
@@ -1,0 +1,16 @@
+<ntp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-cfg">
+  <peer-vrfs>
+    <peer-vrf>
+      <vrf-name>default</vrf-name>
+      <peer-ipv4s>
+        <peer-ipv4>
+          <address-ipv4>10.0.0.1</address-ipv4>
+          <peer-type-ipv4>
+            <peer-type>server</peer-type>
+          </peer-type-ipv4>
+        </peer-ipv4>
+      </peer-ipv4s>
+    </peer-vrf>
+  </peer-vrfs>
+</ntp>
+

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-22-ydk.py
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-22-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: cd-encode-config-ip-ntp-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ip import Cisco_IOS_XR_ip_ntp_cfg as xr_ip_ntp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
+    peer_ipv4.address_ipv4 = "10.0.0.1"
+    peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.source_interface = "Loopback0"
+    peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
+    peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create config object
+    config_ntp(ntp)  # add object configuration
+
+    print(codec.encode(provider, ntp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/ip/cd-encode-config-ip-ntp-22-ydk.xml
@@ -1,0 +1,18 @@
+<ntp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-cfg">
+  <peer-vrfs>
+    <peer-vrf>
+      <vrf-name>default</vrf-name>
+      <peer-ipv4s>
+        <peer-ipv4>
+          <address-ipv4>10.0.0.1</address-ipv4>
+          <peer-type-ipv4>
+            <peer-type>server</peer-type>
+            <source-interface>Loopback0</source-interface>
+          </peer-type-ipv4>
+        </peer-ipv4>
+      </peer-ipv4s>
+    </peer-vrf>
+  </peer-vrfs>
+  <update-calendar></update-calendar>
+</ntp>
+


### PR DESCRIPTION
Includes two custom apps for performing XML encoding of NTP configuration:
cd-encode-config-ip-ntp-20-ydk.py - IPv4 server
cd-encode-config-ip-ntp-22-ydk.py - IPv4 server w/source intf
