### PR TITLE
Add sample apps for encoding LLDP config

### DIFF
--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-10-ydk.py
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ethernet-lldp-cfg.
+
+usage: cd-encode-config-ethernet-lldp-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ethernet import Cisco_IOS_XR_ethernet_lldp_cfg as xr_ethernet_lldp_cfg
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = xr_ethernet_lldp_cfg.Lldp()  # create config object
+    config_lldp(lldp)  # add object configuration
+
+    # print(codec.encode(provider, lldp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-20-ydk.py
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-20-ydk.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ethernet-lldp-cfg.
+
+usage: cd-encode-config-ethernet-lldp-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ethernet import Cisco_IOS_XR_ethernet_lldp_cfg \
+    as xr_ethernet_lldp_cfg
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.enable = True
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = xr_ethernet_lldp_cfg.Lldp()  # create config object
+    config_lldp(lldp)  # add object configuration
+
+    print(codec.encode(provider, lldp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-20-ydk.xml
@@ -1,0 +1,4 @@
+<lldp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-lldp-cfg">
+  <enable>true</enable>
+</lldp>
+

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-22-ydk.py
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-22-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ethernet-lldp-cfg.
+
+usage: cd-encode-config-ethernet-lldp-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ethernet import Cisco_IOS_XR_ethernet_lldp_cfg \
+    as xr_ethernet_lldp_cfg
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.enable = True
+    lldp.timer = 15
+    lldp.holdtime = 60
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = xr_ethernet_lldp_cfg.Lldp()  # create config object
+    config_lldp(lldp)  # add object configuration
+
+    print(codec.encode(provider, lldp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-22-ydk.xml
@@ -1,0 +1,6 @@
+<lldp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-lldp-cfg">
+  <enable>true</enable>
+  <holdtime>60</holdtime>
+  <timer>15</timer>
+</lldp>
+

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-24-ydk.py
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-24-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-ethernet-lldp-cfg.
+
+usage: cd-encode-config-ethernet-lldp-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.ethernet import Cisco_IOS_XR_ethernet_lldp_cfg \
+    as xr_ethernet_lldp_cfg
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.enable = True
+    lldp.timer = 15
+    lldp.holdtime = 60
+    lldp.enable_subintf = True
+    lldp.tlv_select = lldp.TlvSelect()
+    lldp.tlv_select.management_address.disable = True
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = xr_ethernet_lldp_cfg.Lldp()  # create config object
+    config_lldp(lldp)  # add object configuration
+
+    print(codec.encode(provider, lldp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/ethernet/cd-encode-config-ethernet-lldp-24-ydk.xml
@@ -1,0 +1,12 @@
+<lldp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-lldp-cfg">
+  <enable>true</enable>
+  <enable-subintf>true</enable-subintf>
+  <holdtime>60</holdtime>
+  <timer>15</timer>
+  <tlv-select>
+    <management-address>
+      <disable>true</disable>
+    </management-address>
+  </tlv-select>
+</lldp>
+


### PR DESCRIPTION
Includes one boilerplate app and three custom apps to encode LLDP
configuration in XML:
cd-encode-config-ethernet-lldp-20-ydk.py - Basic LLDP
cd-encode-config-ethernet-lldp-22-ydk.py - LLDP w/custom timers
cd-encode-config-ethernet-lldp-24-ydk.py - LLDP w/subintf and TLV select
