### PR TITLE
Add sample apps for encoding CDP config

### DIFF
--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-10-ydk.py
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-cdp-cfg.
+
+usage: cd-encode-config-cdp-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cdp import Cisco_IOS_XR_cdp_cfg as xr_cdp_cfg
+import logging
+
+
+def config_cdp(cdp):
+    """Add config data to cdp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    cdp = xr_cdp_cfg.Cdp()  # create config object
+    config_cdp(cdp)  # add object configuration
+
+    # print(codec.encode(provider, cdp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-20-ydk.py
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-20-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-cdp-cfg.
+
+usage: cd-encode-config-cdp-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cdp import Cisco_IOS_XR_cdp_cfg as xr_cdp_cfg
+import logging
+
+
+def config_cdp(cdp):
+    """Add config data to cdp object."""
+    cdp.enable = True
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    cdp = xr_cdp_cfg.Cdp()  # create config object
+    config_cdp(cdp)  # add object configuration
+
+    print(codec.encode(provider, cdp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-20-ydk.xml
@@ -1,0 +1,4 @@
+<cdp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg">
+  <enable>true</enable>
+</cdp>
+

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-22-ydk.py
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-22-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-cdp-cfg.
+
+usage: cd-encode-config-cdp-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cdp import Cisco_IOS_XR_cdp_cfg as xr_cdp_cfg
+import logging
+
+
+def config_cdp(cdp):
+    """Add config data to cdp object."""
+    cdp.enable = True
+    cdp.timer = 15
+    cdp.hold_time = 60
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    cdp = xr_cdp_cfg.Cdp()  # create config object
+    config_cdp(cdp)  # add object configuration
+
+    print(codec.encode(provider, cdp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-22-ydk.xml
@@ -1,0 +1,6 @@
+<cdp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg">
+  <enable>true</enable>
+  <hold-time>60</hold-time>
+  <timer>15</timer>
+</cdp>
+

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-24-ydk.py
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-24-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-cdp-cfg.
+
+usage: cd-encode-config-cdp-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cdp import Cisco_IOS_XR_cdp_cfg as xr_cdp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_cdp(cdp):
+    """Add config data to cdp object."""
+    cdp.enable = True
+    cdp.timer = 15
+    cdp.hold_time = 60
+    cdp.log_adjacency = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    cdp = xr_cdp_cfg.Cdp()  # create config object
+    config_cdp(cdp)  # add object configuration
+
+    print(codec.encode(provider, cdp))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/cdp/cd-encode-config-cdp-24-ydk.xml
@@ -1,0 +1,7 @@
+<cdp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg">
+  <enable>true</enable>
+  <hold-time>60</hold-time>
+  <log-adjacency></log-adjacency>
+  <timer>15</timer>
+</cdp>
+


### PR DESCRIPTION
Includes one boilerplate app and three custom apps to encode CDP
configuration in XML:
cd-encode-config-cdp-20-ydk.py - Basic CDP
cd-encode-config-cdp-22-ydk.py - CDP w/custom timers
cd-encode-config-cdp-24-ydk.py - CDP w/adjacency logging
