### PR TITLE
Add sample apps for encoding gRPC config

### DIFF
--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-10-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-10-ydk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.man import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    # print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-20-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-20-ydk.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.man import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-20-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-20-ydk.xml
@@ -1,0 +1,4 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <enable></enable>
+</grpc>
+

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-22-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-22-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.man import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+    grpc.tls.enable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-22-ydk.xml
@@ -1,0 +1,7 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <enable></enable>
+  <tls>
+    <enable></enable>
+  </tls>
+</grpc>
+

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-24-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-24-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.man import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+    grpc.max_request_per_user = 8
+    grpc.max_request_total = 32
+    grpc.tls.enable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-24-ydk.xml
@@ -1,0 +1,9 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <enable></enable>
+  <max-request-per-user>8</max-request-per-user>
+  <max-request-total>32</max-request-total>
+  <tls>
+    <enable></enable>
+  </tls>
+</grpc>
+


### PR DESCRIPTION
Includes one boilerplate app and three custom apps to encode gRPC
configuration in XML:
cd-encode-config-man-ems-20-ydk.py
cd-encode-config-man-ems-22-ydk.py
cd-encode-config-man-ems-24-ydk.py
