### PR TITLE
Add sample apps for encoding (IPv6) gRPC config

### DIFF
--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-21-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-21-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-21-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+    grpc.address_family = "ipv6"
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-21-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-21-ydk.xml
@@ -1,0 +1,5 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <address-family>ipv6</address-family>
+  <enable></enable>
+</grpc>
+

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-23-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-23-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-23-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+    grpc.address_family = "ipv6"
+    grpc.tls.enable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-23-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-23-ydk.xml
@@ -1,0 +1,8 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <address-family>ipv6</address-family>
+  <enable></enable>
+  <tls>
+    <enable></enable>
+  </tls>
+</grpc>
+

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-25-ydk.py
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-25-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model Cisco-IOS-XR-man-ems-cfg.
+
+usage: cd-encode-config-man-ems-25-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_man_ems_cfg as xr_man_ems_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_grpc(grpc):
+    """Add config data to grpc object."""
+    grpc.enable = Empty()
+    grpc.address_family = "ipv6"
+    grpc.max_request_per_user = 8
+    grpc.max_request_total = 32
+    grpc.tls.enable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    grpc = xr_man_ems_cfg.Grpc()  # create config object
+    config_grpc(grpc)  # add object configuration
+
+    print(codec.encode(provider, grpc))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-25-ydk.xml
+++ b/samples/basic/codec/ydk/models/man/cd-encode-config-man-ems-25-ydk.xml
@@ -1,0 +1,10 @@
+<grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-cfg">
+  <address-family>ipv6</address-family>
+  <enable></enable>
+  <max-request-per-user>8</max-request-per-user>
+  <max-request-total>32</max-request-total>
+  <tls>
+    <enable></enable>
+  </tls>
+</grpc>
+


### PR DESCRIPTION
Includes one boilerplate app and three custom apps to encode IPv6 gRPC
configuration in XML:
cd-encode-config-man-ems-21-ydk.py - Basic gRPC
cd-encode-config-man-ems-23-ydk.py - gRPC with TLS
cd-encode-config-man-ems-25-ydk.py - gRPC with TLS and max request
