### PR TITLE
Update address family in OC-BGP CRUD apps

### DIFF
--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     v4_afi_safi = bgp.global_.afi_safis.AfiSafi()
-    v4_afi_safi.afi_safi_name = "ipv4-unicast"
-    v4_afi_safi.config.afi_safi_name = "ipv4-unicast"
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     v4_afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(v4_afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     ibgp_pg.config.peer_as = 65001
     ibgp_pg.transport.config.local_address = "Loopback0"
     v4_afi_safi = ibgp_pg.afi_safis.AfiSafi()
-    v4_afi_safi.afi_safi_name = "ipv4-unicast"
-    v4_afi_safi.config.afi_safi_name = "ipv4-unicast"
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     v4_afi_safi.config.enabled = True
     ibgp_pg.afi_safis.afi_safi.append(v4_afi_safi)
     bgp.peer_groups.peer_group.append(ibgp_pg)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv4-unicast"
-    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv4-unicast"
-    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv4-unicast"
-    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv4-unicast"
-    afi_safi.config.afi_safi_name = "ipv4-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
@@ -35,6 +35,7 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_bgp \
     as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
 import logging
 
 
@@ -43,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -55,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = "ipv6-unicast"
-    afi_safi.config.afi_safi_name = "ipv6-unicast"
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")


### PR DESCRIPTION
Current version of OC-BGP model defines address families as identities.
Sample apps now use this definition.
