### PR TITLE
Add sample apps for encoding OC BGP config

### DIFF
--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-10-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-40-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    v4_afi_safi = bgp.global_.afi_safis.AfiSafi()
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(v4_afi_safi)
+
+    # configure IBGP peer group
+    ibgp_pg = bgp.peer_groups.PeerGroup()
+    ibgp_pg.peer_group_name = "IBGP"
+    ibgp_pg.config.peer_group_name = "IBGP"
+    ibgp_pg.config.peer_as = 65001
+    ibgp_pg.transport.config.local_address = "Loopback0"
+    v4_afi_safi = ibgp_pg.afi_safis.AfiSafi()
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.config.enabled = True
+    ibgp_pg.afi_safis.afi_safi.append(v4_afi_safi)
+    bgp.peer_groups.peer_group.append(ibgp_pg)
+
+    # configure IBGP neighbor
+    ibgp_nbr = bgp.neighbors.Neighbor()
+    ibgp_nbr.neighbor_address = "172.16.255.2"
+    ibgp_nbr.config.neighbor_address = "172.16.255.2"
+    ibgp_nbr.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(ibgp_nbr)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.xml
@@ -1,0 +1,49 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>172.16.255.2</neighbor-address>
+      <config>
+        <neighbor-address>172.16.255.2</neighbor-address>
+        <peer-group>IBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>IBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65001</peer-as>
+        <peer-group-name>IBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-41-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.xml
@@ -1,0 +1,49 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>2001:db8::ff:2</neighbor-address>
+      <config>
+        <neighbor-address>2001:db8::ff:2</neighbor-address>
+        <peer-group>IBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>IBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65001</peer-as>
+        <peer-group-name>IBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-42-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.export_policy.append("POLICY2")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "172.16.255.2"
+    neighbor.config.neighbor_address = "172.16.255.2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.xml
@@ -1,0 +1,54 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>172.16.255.2</neighbor-address>
+      <config>
+        <neighbor-address>172.16.255.2</neighbor-address>
+        <peer-group>IBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>IBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <apply-policy>
+            <config>
+              <export-policy>POLICY2</export-policy>
+            </config>
+          </apply-policy>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65001</peer-as>
+        <peer-group-name>IBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-43-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "IBGP"
+    peer_group.config.peer_group_name = "IBGP"
+    peer_group.config.peer_as = 65001
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.export_policy.append("POLICY2")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.neighbor_address = "2001:db8::ff:2"
+    neighbor.config.peer_group = "IBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.xml
@@ -1,0 +1,54 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>2001:db8::ff:2</neighbor-address>
+      <config>
+        <neighbor-address>2001:db8::ff:2</neighbor-address>
+        <peer-group>IBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>IBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <apply-policy>
+            <config>
+              <export-policy>POLICY2</export-policy>
+            </config>
+          </apply-policy>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65001</peer-as>
+        <peer-group-name>IBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-44-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "EBGP"
+    peer_group.config.peer_group_name = "EBGP"
+    peer_group.config.peer_as = 65002
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.import_policy.append("POLICY3")
+    afi_safi.apply_policy.config.export_policy.append("POLICY1")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "192.168.1.1"
+    neighbor.config.neighbor_address = "192.168.1.1"
+    neighbor.config.peer_group = "EBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.xml
@@ -1,0 +1,55 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>192.168.1.1</neighbor-address>
+      <config>
+        <neighbor-address>192.168.1.1</neighbor-address>
+        <peer-group>EBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>EBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <apply-policy>
+            <config>
+              <export-policy>POLICY1</export-policy>
+              <import-policy>POLICY3</import-policy>
+            </config>
+          </apply-policy>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65002</peer-as>
+        <peer-group-name>EBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-bgp.
+
+usage: cd-encode-oc-bgp-45-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_bgp \
+    as oc_bgp
+from ydk.models.openconfig import openconfig_bgp_types as oc_bgp_types
+import logging
+
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    bgp.global_.config.as_ = 65001
+    afi_safi = bgp.global_.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    bgp.global_.afi_safis.afi_safi.append(afi_safi)
+
+    # configure IBGP peer group
+    peer_group = bgp.peer_groups.PeerGroup()
+    peer_group.peer_group_name = "EBGP"
+    peer_group.config.peer_group_name = "EBGP"
+    peer_group.config.peer_as = 65002
+    peer_group.transport.config.local_address = "Loopback0"
+    afi_safi = peer_group.afi_safis.AfiSafi()
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.config.enabled = True
+    afi_safi.apply_policy.config.import_policy.append("POLICY3")
+    afi_safi.apply_policy.config.export_policy.append("POLICY1")
+    peer_group.afi_safis.afi_safi.append(afi_safi)
+    bgp.peer_groups.peer_group.append(peer_group)
+
+    # configure IBGP neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8:e:1::1"
+    neighbor.config.neighbor_address = "2001:db8:e:1::1"
+    neighbor.config.peer_group = "EBGP"
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    bgp = oc_bgp.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, bgp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.xml
@@ -1,0 +1,55 @@
+<bgp xmlns="http://openconfig.net/yang/bgp">
+  <global>
+    <afi-safis>
+      <afi-safi>
+        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <config>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <enabled>true</enabled>
+        </config>
+      </afi-safi>
+    </afi-safis>
+    <config>
+      <as>65001</as>
+    </config>
+  </global>
+  <neighbors>
+    <neighbor>
+      <neighbor-address>2001:db8:e:1::1</neighbor-address>
+      <config>
+        <neighbor-address>2001:db8:e:1::1</neighbor-address>
+        <peer-group>EBGP</peer-group>
+      </config>
+    </neighbor>
+  </neighbors>
+  <peer-groups>
+    <peer-group>
+      <peer-group-name>EBGP</peer-group-name>
+      <afi-safis>
+        <afi-safi>
+          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <apply-policy>
+            <config>
+              <export-policy>POLICY1</export-policy>
+              <import-policy>POLICY3</import-policy>
+            </config>
+          </apply-policy>
+          <config>
+            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+            <enabled>true</enabled>
+          </config>
+        </afi-safi>
+      </afi-safis>
+      <config>
+        <peer-as>65002</peer-as>
+        <peer-group-name>EBGP</peer-group-name>
+      </config>
+      <transport>
+        <config>
+          <local-address>Loopback0</local-address>
+        </config>
+      </transport>
+    </peer-group>
+  </peer-groups>
+</bgp>
+


### PR DESCRIPTION
Includes one boilerplate app and six custom apps to encode OC BGP
configuration in XML:
cd-encode-oc-bgp-10-ydk.py - encode boilerplate
cd-encode-oc-bgp-40-ydk.py - IPv4 iBGP neighbor group w/o policy
cd-encode-oc-bgp-41-ydk.py - IPv6 iBGP neighbor group w/o policy
cd-encode-oc-bgp-42-ydk.py - IPv4 iBGP neighbor group w/ policy
cd-encode-oc-bgp-43-ydk.py - IPv6 iBGP neighbor group w/ policy
cd-encode-oc-bgp-44-ydk.py - IPv4 eBGP neighbor group w/ policy
cd-encode-oc-bgp-45-ydk.py - IPv6 eBGP neighbor group w/ policy
