### PR TITLE
Add sample apps for RSVP-TE configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    # crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth percentage 100
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth percentage 100
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.xml
@@ -1,0 +1,29 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth 1000000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth 1000000
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.xml
@@ -1,0 +1,27 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.xml
@@ -1,0 +1,33 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>25</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>25</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.xml
@@ -1,0 +1,31 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>250000</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>250000</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-create-xr-ip-rsvp-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.xml
@@ -1,0 +1,27 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <mam>
+          <bc0-bandwidth>600000</bc0-bandwidth>
+          <bc1-bandwidth>400000</bc1-bandwidth>
+          <max-resv-bandwidth>1000000</max-resv-bandwidth>
+        </mam>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <mam>
+          <bc0-bandwidth>600000</bc0-bandwidth>
+          <bc1-bandwidth>400000</bc1-bandwidth>
+          <max-resv-bandwidth>1000000</max-resv-bandwidth>
+        </mam>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-delete-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    # delete configuration on NETCONF device
+    # crud.delete(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-delete-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    # delete configuration on NETCONF device
+    crud.delete(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-read-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-read-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-read-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+def process_rsvp(rsvp):
+    """Process data in rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # read data from NETCONF device
+    # rsvp = crud.read(provider, rsvp)
+    process_rsvp(rsvp)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-update-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-update-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: nc-update-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # update configuration on NETCONF device
+    # crud.update(provider, rsvp)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and six custom apps to configure
RSVP-TE (non-DS-TE and DS-TE with RDM/MAM bandwidth pools):
nc-create-xr-ip-rsvp-cfg-10-ydk.py - create boilerplate
nc-create-xr-ip-rsvp-cfg-20-ydk.py - interface BW percentage
nc-create-xr-ip-rsvp-cfg-22-ydk.py - interface BW absolute
nc-create-xr-ip-rsvp-cfg-24-ydk.py - interface RDM BW percentage
nc-create-xr-ip-rsvp-cfg-26-ydk.py - interface RDM BW absolute
nc-create-xr-ip-rsvp-cfg-28-ydk.py - interface MAM BW
nc-delete-xr-ip-rsvp-cfg-10-ydk.py - delete boilerplate
nc-delete-xr-ip-rsvp-cfg-20-ydk.py - delete all RSVP configuration
nc-read-xr-ip-rsvp-cfg-10-ydk.py   - read boilerplate
nc-update-xr-ip-rsvp-cfg-10-ydk.py - update boilerplate
