### PR TITLE
Add sample apps for encoding RSVP-TE configuration

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.xml
@@ -1,0 +1,29 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.xml
@@ -1,0 +1,27 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <rdm-keyword>not-specified</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.xml
@@ -1,0 +1,33 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>25</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bandwidth-mode>percentage</bandwidth-mode>
+          <bc0-bandwidth>100</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>25</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.xml
@@ -1,0 +1,31 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>250000</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <rdm>
+          <bc0-bandwidth>1000000</bc0-bandwidth>
+          <bc0-keyword>not-specified</bc0-keyword>
+          <bc1-bandwidth>250000</bc1-bandwidth>
+          <bc1-keyword>sub-pool</bc1-keyword>
+          <rdm-keyword>rdm</rdm-keyword>
+        </rdm>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: cd-encode-xr-ip-rsvp-cfg-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, rsvp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.xml
@@ -1,0 +1,27 @@
+<rsvp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rsvp-cfg">
+  <interfaces>
+    <interface>
+      <name>GigabitEthernet0/0/0/0</name>
+      <bandwidth>
+        <mam>
+          <bc0-bandwidth>600000</bc0-bandwidth>
+          <bc1-bandwidth>400000</bc1-bandwidth>
+          <max-resv-bandwidth>1000000</max-resv-bandwidth>
+        </mam>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+    <interface>
+      <name>GigabitEthernet0/0/0/1</name>
+      <bandwidth>
+        <mam>
+          <bc0-bandwidth>600000</bc0-bandwidth>
+          <bc1-bandwidth>400000</bc1-bandwidth>
+          <max-resv-bandwidth>1000000</max-resv-bandwidth>
+        </mam>
+      </bandwidth>
+      <enable></enable>
+    </interface>
+  </interfaces>
+</rsvp>
+


### PR DESCRIPTION
Includes one boilerplate app and five custom apps to encode RSVP-TE
configuration in XML:
cd-encode-xr-ip-rsvp-cfg-10-ydk.py - encode boilerplate
cd-encode-xr-ip-rsvp-cfg-20-ydk.py - interface BW percentage
cd-encode-xr-ip-rsvp-cfg-22-ydk.py - interface BW absolute
cd-encode-xr-ip-rsvp-cfg-24-ydk.py - interface RDM BW percentage
cd-encode-xr-ip-rsvp-cfg-26-ydk.py - interface RDM BW absolute
cd-encode-xr-ip-rsvp-cfg-28-ydk.py - interface MAM BW
