### PR TITLE
Add sample apps for IPv6 NTP configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: nc-create-xr-ip-ntp-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import logging
+
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ntp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.txt
@@ -1,0 +1,4 @@
+ntp
+ server ipv6 2001:db8::a:1
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.xml
@@ -1,0 +1,16 @@
+<ntp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-cfg">
+  <peer-vrfs>
+    <peer-vrf>
+      <vrf-name>default</vrf-name>
+      <peer-ipv6s>
+        <peer-ipv6>
+          <address-ipv6>2001:db8::a:1</address-ipv6>
+          <peer-type-ipv6>
+            <peer-type>server</peer-type>
+          </peer-type-ipv6>
+        </peer-ipv6>
+      </peer-ipv6s>
+    </peer-vrf>
+  </peer-vrfs>
+</ntp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: nc-create-xr-ip-ntp-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.source_interface = "Loopback0"
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ntp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.txt
@@ -1,0 +1,5 @@
+ntp
+ server ipv6 2001:db8::a:1 source Loopback0
+ update-calendar
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.xml
@@ -1,0 +1,18 @@
+<ntp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-cfg">
+  <peer-vrfs>
+    <peer-vrf>
+      <vrf-name>default</vrf-name>
+      <peer-ipv6s>
+        <peer-ipv6>
+          <address-ipv6>2001:db8::a:1</address-ipv6>
+          <peer-type-ipv6>
+            <peer-type>server</peer-type>
+            <source-interface>Loopback0</source-interface>
+          </peer-type-ipv6>
+        </peer-ipv6>
+      </peer-ipv6s>
+    </peer-vrf>
+  </peer-vrfs>
+  <update-calendar></update-calendar>
+</ntp>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: nc-create-xr-ip-ntp-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "MGMT-PLANE"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.ntp_version = 4
+    peer_type_ipv6.iburst = Empty()
+    peer_type_ipv6.preferred_peer = Empty()
+    peer_type_ipv6.source_interface = "Loopback0"
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ntp)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.1
+ntp
+ server vrf MGMT-PLANE ipv6 2001:db8::a:1 version 4 prefer iburst source Loopback0
+ update-calendar
+!
+end
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.xml
@@ -1,0 +1,21 @@
+<ntp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-cfg">
+  <peer-vrfs>
+    <peer-vrf>
+      <vrf-name>MGMT-PLANE</vrf-name>
+      <peer-ipv6s>
+        <peer-ipv6>
+          <address-ipv6>2001:db8::a:1</address-ipv6>
+          <peer-type-ipv6>
+            <peer-type>server</peer-type>
+            <iburst></iburst>
+            <ntp-version>4</ntp-version>
+            <preferred-peer></preferred-peer>
+            <source-interface>Loopback0</source-interface>
+          </peer-type-ipv6>
+        </peer-ipv6>
+      </peer-ipv6s>
+    </peer-vrf>
+  </peer-vrfs>
+  <update-calendar></update-calendar>
+</ntp>
+


### PR DESCRIPTION
Introduces three custom apps to configure NTP for IPv6:
nc-create-xr-ip-ntp-cfg-21-ydk.py - IPv6 server
nc-create-xr-ip-ntp-cfg-23-ydk.py - IPv6 server w/source intf
nc-create-xr-ip-ntp-cfg-25-ydk.py - VRF-aware NTPv6 with iburst