### PR TITLE
Add sample apps for IPv6 DNS configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # host name "east"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "east"
+    ipv6_host.address.append("2001:db8::1")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "west"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "west"
+    ipv6_host.address.append("2001:db8::2")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "north"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "north"
+    ipv6_host.address.append("2001:db8::3")
+    ipv6_host.address.append("2001:db8::4")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "south"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "south"
+    ipv6_host.address.append("2001:db8::5")
+    ipv6_host.address.append("2001:db8::6")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain ipv6 host east 2001:db8::1
+domain ipv6 host west 2001:db8::2
+domain ipv6 host north 2001:db8::3 2001:db8::4
+domain ipv6 host south 2001:db8::5 2001:db8::6
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.xml
@@ -1,0 +1,28 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>default</vrf-name>
+      <ipv6-hosts>
+        <ipv6-host>
+          <host-name>east</host-name>
+          <address>2001:db8::1</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>west</host-name>
+          <address>2001:db8::2</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>north</host-name>
+          <address>2001:db8::3</address>
+          <address>2001:db8::4</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>south</host-name>
+          <address>2001:db8::5</address>
+          <address>2001:db8::6</address>
+        </ipv6-host>
+      </ipv6-hosts>
+    </vrf>
+  </vrfs>
+</ip-domain>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    vrf.name = "example.com"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:8000::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:8000::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:8000::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain name example.com
+domain name-server 2001:db8:8000::1
+domain name-server 2001:db8:8000::2
+domain name-server 2001:db8:8000::3
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.xml
@@ -1,0 +1,23 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>default</vrf-name>
+      <name>example.com</name>
+      <servers>
+        <server>
+          <order>0</order>
+          <server-address>2001:db8:8000::1</server-address>
+        </server>
+        <server>
+          <order>1</order>
+          <server-address>2001:db8:8000::2</server-address>
+        </server>
+        <server>
+          <order>2</order>
+          <server-address>2001:db8:8000::3</server-address>
+        </server>
+      </servers>
+    </vrf>
+  </vrfs>
+</ip-domain>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "example.com"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "example.net"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "example.org"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:8000::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:8000::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:8000::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.0.1
+domain list example.com
+domain list example.net
+domain list example.org
+domain name-server 2001:db8:8000::1
+domain name-server 2001:db8:8000::2
+domain name-server 2001:db8:8000::3
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.xml
@@ -1,0 +1,36 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>default</vrf-name>
+      <lists>
+        <list>
+          <list-name>example.com</list-name>
+          <order>0</order>
+        </list>
+        <list>
+          <list-name>example.net</list-name>
+          <order>1</order>
+        </list>
+        <list>
+          <list-name>example.org</list-name>
+          <order>2</order>
+        </list>
+      </lists>
+      <servers>
+        <server>
+          <order>0</order>
+          <server-address>2001:db8:8000::1</server-address>
+        </server>
+        <server>
+          <order>1</order>
+          <server-address>2001:db8:8000::2</server-address>
+        </server>
+        <server>
+          <order>2</order>
+          <server-address>2001:db8:8000::3</server-address>
+        </server>
+      </servers>
+    </vrf>
+  </vrfs>
+</ip-domain>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-31-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # host name "ruby"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "ruby"
+    ipv6_host.address.append("2001:db8:a::1")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "flame"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "flame"
+    ipv6_host.address.append("2001:db8:a::2")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "crimson"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "crimson"
+    ipv6_host.address.append("2001:db8:a::3")
+    ipv6_host.address.append("2001:db8:a::4")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "raspberry"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "raspberry"
+    ipv6_host.address.append("2001:db8:a::5")
+    ipv6_host.address.append("2001:db8:a::6")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED ipv6 host ruby 2001:db8:a::1
+domain vrf RED ipv6 host flame 2001:db8:a::2
+domain vrf RED ipv6 host crimson 2001:db8:a::3 2001:db8:a::4
+domain vrf RED ipv6 host raspberry 2001:db8:a::5 2001:db8:a::6
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.xml
@@ -1,0 +1,28 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>RED</vrf-name>
+      <ipv6-hosts>
+        <ipv6-host>
+          <host-name>ruby</host-name>
+          <address>2001:db8:a::1</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>flame</host-name>
+          <address>2001:db8:a::2</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>crimson</host-name>
+          <address>2001:db8:a::3</address>
+          <address>2001:db8:a::4</address>
+        </ipv6-host>
+        <ipv6-host>
+          <host-name>raspberry</host-name>
+          <address>2001:db8:a::5</address>
+          <address>2001:db8:a::6</address>
+        </ipv6-host>
+      </ipv6-hosts>
+    </vrf>
+  </vrfs>
+</ip-domain>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-33-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    vrf.name = "red.example"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:800a::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:800a::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:800a::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED name red.example
+domain vrf RED name-server 2001:db8:800a::1
+domain vrf RED name-server 2001:db8:800a::2
+domain vrf RED name-server 2001:db8:800a::3
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.xml
@@ -1,0 +1,23 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>RED</vrf-name>
+      <name>red.example</name>
+      <servers>
+        <server>
+          <order>0</order>
+          <server-address>2001:db8:800a::1</server-address>
+        </server>
+        <server>
+          <order>1</order>
+          <server-address>2001:db8:800a::2</server-address>
+        </server>
+        <server>
+          <order>2</order>
+          <server-address>2001:db8:800a::3</server-address>
+        </server>
+      </servers>
+    </vrf>
+  </vrfs>
+</ip-domain>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: nc-create-xr-ip-domain-cfg-35-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import logging
+
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "rouge.example"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "vermelho.example"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "rojo.example"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:800a::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:800a::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:800a::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, ip_domain)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.1.1
+domain vrf RED list rouge.example
+domain vrf RED list vermelho.example
+domain vrf RED list rojo.example
+domain vrf RED name-server 2001:db8:800a::1
+domain vrf RED name-server 2001:db8:800a::2
+domain vrf RED name-server 2001:db8:800a::3
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.xml
@@ -1,0 +1,36 @@
+<ip-domain xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ip-domain-cfg">
+  <vrfs>
+    <vrf>
+      <vrf-name>RED</vrf-name>
+      <lists>
+        <list>
+          <list-name>rouge.example</list-name>
+          <order>0</order>
+        </list>
+        <list>
+          <list-name>vermelho.example</list-name>
+          <order>1</order>
+        </list>
+        <list>
+          <list-name>rojo.example</list-name>
+          <order>2</order>
+        </list>
+      </lists>
+      <servers>
+        <server>
+          <order>0</order>
+          <server-address>2001:db8:800a::1</server-address>
+        </server>
+        <server>
+          <order>1</order>
+          <server-address>2001:db8:800a::2</server-address>
+        </server>
+        <server>
+          <order>2</order>
+          <server-address>2001:db8:800a::3</server-address>
+        </server>
+      </servers>
+    </vrf>
+  </vrfs>
+</ip-domain>
+


### PR DESCRIPTION
Introduces six custom apps to configure DNS for an IPv6 network:
nc-create-xr-ip-domain-cfg-21-ydk.py - static (local) IPv6 hosts
nc-create-xr-ip-domain-cfg-23-ydk.py - single domain, various IPv6 servers
nc-create-xr-ip-domain-cfg-25-ydk.py - various domains, various IPv6 srvs
nc-create-xr-ip-domain-cfg-31-ydk.py - VRF-aware static (local) IPv6 hosts
nc-create-xr-ip-domain-cfg-33-ydk.py - VRF/ single dom, various IPv6 srvs
nc-create-xr-ip-domain-cfg-35-ydk.py - VRF/ various domains/IPv6 servers