### PR TITLE
Fix missing leaf to enable OSPFv3 process

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -45,6 +45,7 @@ def config_ospfv3(ospfv3):
     process = ospfv3.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.enable = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.xml
@@ -23,6 +23,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <enable></enable>
     </process>
   </processes>
 </ospfv3>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -45,6 +45,7 @@ def config_ospfv3(ospfv3):
     process = ospfv3.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.101"
+    process.enable = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.xml
@@ -34,6 +34,7 @@
         </area-addresses>
         <router-id>172.16.255.101</router-id>
       </default-vrf>
+      <enable></enable>
     </process>
   </processes>
 </ospfv3>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -45,6 +45,7 @@ def config_ospfv3(ospfv3):
     process = ospfv3.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.101"
+    process.enable = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.101</router-id>
       </default-vrf>
+      <enable></enable>
     </process>
   </processes>
 </ospfv3>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -45,6 +45,7 @@ def config_ospfv3(ospfv3):
     process = ospfv3.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.101"
+    process.enable = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.101</router-id>
       </default-vrf>
+      <enable></enable>
     </process>
   </processes>
 </ospfv3>


### PR DESCRIPTION
Apps were missing leaf required to enable OSPFv3 process.  Without the
leaf, the configuration is rejected by the device.