### PR TITLE
Add sample apps for encoding hostname config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: cd-encode-xr-shellutil-cfg-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import logging
+
+
+def config_host_names(host_names):
+    """Add config data to host_names object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+    config_host_names(host_names)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, host_names))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: cd-encode-xr-shellutil-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import logging
+
+
+def config_host_names(host_names):
+    """Add config data to host_names object."""
+    host_names.host_name = "Router"
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+    config_host_names(host_names)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, host_names))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.xml
@@ -1,0 +1,4 @@
+<host-names xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-shellutil-cfg">
+  <host-name>Router</host-name>
+</host-names>
+


### PR DESCRIPTION
Includes one boilerplate app and one custom app to encode hostname
configuration in XML:
cd-encode-xr-shellutil-cfg-10-ydk.py - encode boilerplate
cd-encode-xr-shellutil-cfg-20-ydk.py - hostname config