### PR TITLE
Fix AF identity reference in OC BGP

### DIFF
--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     v4_afi_safi = bgp.global_.afi_safis.AfiSafi()
-    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     v4_afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(v4_afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     ibgp_pg.config.peer_as = 65001
     ibgp_pg.transport.config.local_address = "Loopback0"
     v4_afi_safi = ibgp_pg.afi_safis.AfiSafi()
-    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    v4_afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    v4_afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     v4_afi_safi.config.enabled = True
     ibgp_pg.afi_safis.afi_safi.append(v4_afi_safi)
     bgp.peer_groups.peer_group.append(ibgp_pg)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity
+    afi_safi.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
+    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6UnicastIdentity()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")


### PR DESCRIPTION
OC BGP apps had incorrect reference to identity that defines address families.