### PR TITLE
Add datatypes import

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -52,12 +54,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -70,8 +72,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -83,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-24-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -52,12 +54,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -70,8 +72,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -83,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -51,12 +53,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -69,8 +71,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +84,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -51,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_cfg.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_cfg.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -74,8 +76,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -87,8 +89,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -51,12 +53,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -69,8 +71,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +84,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-36-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-36-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -51,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_cfg.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_cfg.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -74,8 +76,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -87,8 +89,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-50-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-50-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -52,12 +54,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -73,8 +75,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
@@ -95,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-51-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-51-ydk.py
@@ -18,7 +18,7 @@
 """
 Create configuration for model Cisco-IOS-XR-clns-isis-cfg.
 
-usage: nc-create-xr-clns-isis-cfg-54-ydk.py [-h] [-v] device
+usage: nc-create-xr-clns-isis-cfg-51-ydk.py [-h] [-v] device
 
 positional arguments:
   device         NETCONF device (ssh://user:password@host:port)
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -52,12 +54,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -73,8 +75,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
@@ -95,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
@@ -18,7 +18,7 @@
 """
 Create configuration for model Cisco-IOS-XR-clns-isis-cfg.
 
-usage: nc-create-xr-clns-isis-cfg-40-ydk.py [-h] [-v] device
+usage: nc-create-xr-clns-isis-cfg-60-ydk.py [-h] [-v] device
 
 positional arguments:
   device         NETCONF device (ssh://user:password@host:port)
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_cfg \
     as xr_clns_isis_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_clns_isis_datatypes \
+    as xr_clns_isis_datatypes
 from ydk.types import Empty
 import logging
 
@@ -52,12 +54,12 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
     metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_cfg.IsisInternalLevelEnum.NOT_SET
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
     transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
@@ -72,8 +74,8 @@ def config_isis(isis):
     interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -85,8 +87,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_cfg.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_cfg.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)


### PR DESCRIPTION
Datatypes now need explicit import after the fix for issue #216.
Previous approach to import datatypes automatically was prone to create
circular dependencies.