### PR TITLE
Remove mapping client config

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
@@ -66,7 +66,6 @@ def config_isis(isis):
     # segment routing
     mpls = xr_clns_isis_cfg.IsisLabelPreferenceEnum.LDP
     af.af_data.segment_routing.mpls = mpls
-    af.af_data.segment_routing.prefix_sid_map.receive = True
     instance.afs.af.append(af)
 
     # loopback interface

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.txt
@@ -5,7 +5,6 @@ router isis DEFAULT
  address-family ipv4 unicast
   metric-style wide
   segment-routing mpls
-  segment-routing prefix-sid-map receive
  !
  interface Loopback0
   passive

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.xml
@@ -16,9 +16,6 @@
             </metric-styles>
             <segment-routing>
               <mpls>ldp</mpls>
-              <prefix-sid-map>
-                <receive>true</receive>
-              </prefix-sid-map>
             </segment-routing>
           </af-data>
         </af>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
@@ -66,7 +66,6 @@ def config_isis(isis):
     # segment routing
     mpls = xr_clns_isis_cfg.IsisLabelPreferenceEnum.LDP
     af.af_data.segment_routing.mpls = mpls
-    af.af_data.segment_routing.prefix_sid_map.receive = True
     instance.afs.af.append(af)
 
     # loopback interface

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.txt
@@ -5,7 +5,6 @@ router isis DEFAULT
  address-family ipv6 unicast
   metric-style wide
   segment-routing mpls
-  segment-routing prefix-sid-map receive
  !
  interface Loopback0
   passive

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.xml
@@ -16,9 +16,6 @@
             </metric-styles>
             <segment-routing>
               <mpls>ldp</mpls>
-              <prefix-sid-map>
-                <receive>true</receive>
-              </prefix-sid-map>
             </segment-routing>
           </af-data>
         </af>


### PR DESCRIPTION
L1 ISIS sample apps were not meant to include mapping client
configuration.