### PR TITLE
Add sample apps for SR mapping configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-create-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on NETCONF device
+    # crud.create(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-create-xr-segment-routing-ms-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.txt
@@ -1,0 +1,11 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv4
+    172.16.255.1/32 4041 range 1
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.xml
@@ -1,0 +1,12 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.16.255.1</ip>
+      <mask>32</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4041</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-create-xr-segment-routing-ms-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.txt
@@ -1,0 +1,11 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv6
+    2001:db8::ff:1/128 4061 range 1
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.xml
@@ -1,0 +1,12 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::ff:1</ip>
+      <mask>128</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4061</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-create-xr-segment-routing-ms-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+    # second set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.17.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 5041
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.txt
@@ -1,0 +1,12 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv4
+    172.16.255.1/32 4041 range 1
+    172.17.255.1/32 5041 range 8
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.xml
@@ -1,0 +1,19 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.16.255.1</ip>
+      <mask>32</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4041</sid-start>
+    </mapping>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.17.255.1</ip>
+      <mask>32</mask>
+      <sid-range>8</sid-range>
+      <sid-start>5041</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-create-xr-segment-routing-ms-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::1ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 5061
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.txt
@@ -1,0 +1,12 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv6
+    2001:db8::ff:1/128 4061 range 1
+    2001:db8::1ff:1/128 5061 range 8
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.xml
@@ -1,0 +1,19 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::ff:1</ip>
+      <mask>128</mask>
+      <sid-range>2</sid-range>
+      <sid-start>4061</sid-start>
+    </mapping>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::1ff:1</ip>
+      <mask>128</mask>
+      <sid-range>8</sid-range>
+      <sid-start>5061</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-delete-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    # delete configuration on NETCONF device
+    # crud.delete(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-20-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-delete-xr-segment-routing-ms-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    # delete configuration on NETCONF device
+    crud.delete(provider, sr)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-read-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-read-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-read-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def process_sr(sr):
+    """Process data in sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+
+    # read data from NETCONF device
+    # sr = crud.read(provider, sr)
+    process_sr(sr)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-update-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-update-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: nc-update-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # update configuration on NETCONF device
+    # crud.update(provider, sr)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and five custom apps to configure segment
routing SID mappings (IPv4 and IPv6):
nc-create-xr-segment-routing-ms-cfg-10-ydk.py - create boilerplate
nc-create-xr-segment-routing-ms-cfg-20-ydk.py - IPv4 single mapping
nc-create-xr-segment-routing-ms-cfg-21-ydk.py - IPv6 single mapping
nc-create-xr-segment-routing-ms-cfg-22-ydk.py - IPv4 multiple mappings
nc-create-xr-segment-routing-ms-cfg-23-ydk.py - IPv6 multiple mappings
nc-delete-xr-segment-routing-ms-cfg-10-ydk.py - delete boilerplate
nc-delete-xr-segment-routing-ms-cfg-20-ydk.py - delete all mapping cfg
nc-read-xr-segment-routing-ms-cfg-10-ydk.py   - read boilerplate
nc-update-xr-segment-routing-ms-cfg-10-ydk.py - update boilerplate