### PR TITLE
Add sample apps for encoding SR mapping config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: cd-encode-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, sr))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: cd-encode-xr-segment-routing-ms-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, sr))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.xml
@@ -1,0 +1,12 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.16.255.1</ip>
+      <mask>32</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4041</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: cd-encode-xr-segment-routing-ms-cfg-21-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, sr))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.xml
@@ -1,0 +1,12 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::ff:1</ip>
+      <mask>128</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4061</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: cd-encode-xr-segment-routing-ms-cfg-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+    # second set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv4"
+    mapping.ip = "172.17.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 5041
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, sr))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.xml
@@ -1,0 +1,19 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.16.255.1</ip>
+      <mask>32</mask>
+      <sid-range>1</sid-range>
+      <sid-start>4041</sid-start>
+    </mapping>
+    <mapping>
+      <af>ipv4</af>
+      <ip>172.17.255.1</ip>
+      <mask>32</mask>
+      <sid-range>8</sid-range>
+      <sid-start>5041</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: cd-encode-xr-segment-routing-ms-cfg-23-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import logging
+
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 2
+    sr.mappings.mapping.append(mapping)
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = "ipv6"
+    mapping.ip = "2001:db8::1ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 5061
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, sr))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.xml
@@ -1,0 +1,19 @@
+<sr xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-cfg">
+  <mappings>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::ff:1</ip>
+      <mask>128</mask>
+      <sid-range>2</sid-range>
+      <sid-start>4061</sid-start>
+    </mapping>
+    <mapping>
+      <af>ipv6</af>
+      <ip>2001:db8::1ff:1</ip>
+      <mask>128</mask>
+      <sid-range>8</sid-range>
+      <sid-start>5061</sid-start>
+    </mapping>
+  </mappings>
+</sr>
+


### PR DESCRIPTION
Includes one boilerplate app and four custom apps to encode SR mapping
configuration in XML:
cd-encode-xr-segment-routing-ms-cfg-10-ydk.py - encode boilerplate
cd-encode-xr-segment-routing-ms-cfg-20-ydk.py - IPv4 single mapping
cd-encode-xr-segment-routing-ms-cfg-21-ydk.py - IPv6 single mapping
cd-encode-xr-segment-routing-ms-cfg-22-ydk.py - IPv4 multiple mappings
cd-encode-xr-segment-routing-ms-cfg-23-ydk.py - IPv6 multiple mappings