### PR TITLE
Update VRF apps to match enum capitalization

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-20-ydk.py
@@ -47,14 +47,14 @@ def config_vrfs(vrfs):
 
     # ipv4 unicast address family
     af = vrf.afs.Af()
-    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.IPV4
-    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.ipv4
+    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.unicast
     af.topology_name = "default"
     af.create = Empty()
 
     # import route targets
     route_target = af.bgp.import_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172
@@ -65,7 +65,7 @@ def config_vrfs(vrfs):
 
     # export route targets
     route_target = af.bgp.export_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-21-ydk.py
@@ -47,14 +47,14 @@ def config_vrfs(vrfs):
 
     # ipv6 unicast address family
     af = vrf.afs.Af()
-    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.IPV6
-    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.ipv6
+    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.unicast
     af.topology_name = "default"
     af.create = Empty()
 
     # import route targets
     route_target = af.bgp.import_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172
@@ -65,7 +65,7 @@ def config_vrfs(vrfs):
 
     # export route targets
     route_target = af.bgp.export_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-20-ydk.py
@@ -50,14 +50,14 @@ def config_vrfs(vrfs):
 
     # ipv4 unicast address family
     af = vrf.afs.Af()
-    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.IPV4
-    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.ipv4
+    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.unicast
     af.topology_name = "default"
     af.create = Empty()
 
     # import route targets
     route_target = af.bgp.import_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172
@@ -68,7 +68,7 @@ def config_vrfs(vrfs):
 
     # export route targets
     route_target = af.bgp.export_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-21-ydk.py
@@ -50,14 +50,14 @@ def config_vrfs(vrfs):
 
     # ipv6 unicast address family
     af = vrf.afs.Af()
-    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.IPV6
-    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_infra_rsi_cfg.VrfAddressFamilyEnum.ipv6
+    af.saf_name = xr_infra_rsi_cfg.VrfSubAddressFamilyEnum.unicast
     af.topology_name = "default"
     af.create = Empty()
 
     # import route targets
     route_target = af.bgp.import_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172
@@ -68,7 +68,7 @@ def config_vrfs(vrfs):
 
     # export route targets
     route_target = af.bgp.export_route_targets.route_targets.RouteTarget()
-    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.AS
+    route_target.type = xr_ipv4_bgp_cfg.BgpVrfRouteTargetEnum.as_
     as_or_four_byte_as = route_target.AsOrFourByteAs()
     as_or_four_byte_as.as_xx = 0
     as_or_four_byte_as.as_ = 65172


### PR DESCRIPTION
As of YDK 0.5.2, enums follow the capitalization used in the YANG model.
Previous versions of YDK were modifying it.