### PR TITLE
Update sample apps to match enum capitalization

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-20-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -66,11 +66,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +82,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-21-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -66,11 +66,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +82,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-30-ydk.py
@@ -50,13 +50,13 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -65,11 +65,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -81,8 +81,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-31-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-31-ydk.py
@@ -50,13 +50,13 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -65,11 +65,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -81,8 +81,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-32-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -70,11 +70,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -86,8 +86,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-33-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-33-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -70,11 +70,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -86,8 +86,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-34-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -66,11 +66,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +82,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-35-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-35-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -66,11 +66,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -82,8 +82,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-40-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     # segment routing
     mpls = xr_clns_isis_cfg.IsisLabelPreferenceEnum.LDP
@@ -69,20 +69,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16041
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -94,8 +94,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-41-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-41-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     # segment routing
     mpls = xr_clns_isis_cfg.IsisLabelPreferenceEnum.LDP
@@ -69,20 +69,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16061
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -94,8 +94,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-52-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-52-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -73,20 +73,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16141
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -98,8 +98,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-53-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-53-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -73,20 +73,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16161
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -98,8 +98,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-54-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-54-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -69,21 +69,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16041
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -94,8 +94,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-55-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-55-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -69,21 +69,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16061
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -94,8 +94,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-56-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-56-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -75,20 +75,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16141
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -100,8 +100,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-57-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-57-ydk.py
@@ -50,18 +50,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -75,20 +75,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16161
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -100,8 +100,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-58-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-58-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5002.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -70,21 +70,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16042
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -95,8 +95,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-59-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-59-ydk.py
@@ -44,20 +44,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5002.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -70,21 +70,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16062
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -95,8 +95,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-60-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-60-ydk.py
@@ -44,23 +44,23 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
-    af.af_data.mpls.level = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    af.af_data.mpls.level = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     af.af_data.mpls.router_id.interface_name = "Loopback0"
     instance.afs.af.append(af)
 
@@ -68,11 +68,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -84,8 +84,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-20-ydk.py
@@ -38,7 +38,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # display link status messages for physical links
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DEFAULT
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.default
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-22-ydk.py
@@ -38,7 +38,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # disable link status messages
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DISABLE
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.disable
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-24-ydk.py
@@ -38,7 +38,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # display link status messages for all interfaces
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.SOFTWARE_INTERFACES
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.software_interfaces
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-20-ydk.py
@@ -38,8 +38,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.US
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.us
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.en
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-22-ydk.py
@@ -38,8 +38,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.CN
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.ZH
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.cn
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.zh
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-24-ydk.py
@@ -38,8 +38,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.DE
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.DE
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.de
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.de
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-26-ydk.py
@@ -38,8 +38,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.BR
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.PT
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.br
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.pt
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-28-ydk.py
@@ -38,8 +38,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.NG
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.ng
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.en
 
 
 if __name__ == "__main__":

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-20-ydk.py
@@ -42,7 +42,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
     peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
     ntp.peer_vrfs.peer_vrf.append(peer_vrf)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-21-ydk.py
@@ -42,7 +42,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
     peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
     ntp.peer_vrfs.peer_vrf.append(peer_vrf)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-22-ydk.py
@@ -43,7 +43,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv4.source_interface = "Loopback0"
     peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
     peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-23-ydk.py
@@ -43,7 +43,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv6.source_interface = "Loopback0"
     peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
     peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-24-ydk.py
@@ -43,7 +43,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv4.ntp_version = 4
     peer_type_ipv4.iburst = Empty()
     peer_type_ipv4.preferred_peer = Empty()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-25-ydk.py
@@ -43,7 +43,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv6.ntp_version = 4
     peer_type_ipv6.iburst = Empty()
     peer_type_ipv6.preferred_peer = Empty()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
@@ -43,9 +43,9 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -53,9 +53,9 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
@@ -43,8 +43,8 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -52,8 +52,8 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
@@ -44,10 +44,10 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
     interface.bandwidth.rdm.bc1_bandwidth = 25
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -56,10 +56,10 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
     interface.bandwidth.rdm.bc1_bandwidth = 25
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
@@ -44,9 +44,9 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
     interface.bandwidth.rdm.bc1_bandwidth = 250000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -55,9 +55,9 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
     interface.bandwidth.rdm.bc1_bandwidth = 250000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-40-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -69,7 +69,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4 unicast
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_afs = neighbor_group.neighbor_group_afs
     neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-41-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-41-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -69,7 +69,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4 unicast
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_afs = neighbor_group.neighbor_group_afs
     neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-42-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-42-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -69,7 +69,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
     neighbor_group_afs = neighbor_group.neighbor_group_afs

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-43-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-43-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -69,7 +69,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
     neighbor_group_afs = neighbor_group.neighbor_group_afs

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-44-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-44-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -68,7 +68,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
     neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-45-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-45-ydk.py
@@ -50,7 +50,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -68,7 +68,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
     neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
@@ -59,7 +59,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
 
     # append area/process config

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
@@ -59,7 +59,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -72,7 +72,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
@@ -59,7 +59,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -73,7 +73,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
@@ -59,7 +59,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -73,7 +73,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -60,7 +60,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
 
     # append area/process config

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -60,7 +60,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -73,7 +73,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -60,7 +60,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -74,7 +74,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -60,7 +60,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -74,7 +74,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -69,11 +69,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -85,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-21-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -69,11 +69,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -85,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
@@ -53,13 +53,13 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -68,11 +68,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -84,8 +84,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-31-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-31-ydk.py
@@ -53,13 +53,13 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -68,11 +68,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -84,8 +84,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -73,11 +73,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -89,8 +89,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-33-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-33-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     instance.afs.af.append(af)
@@ -73,11 +73,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -89,8 +89,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -69,11 +69,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -85,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-35-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-35-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     instance.afs.af.append(af)
@@ -69,11 +69,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -85,8 +85,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-40-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -72,20 +72,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16041
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -97,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-41-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-41-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -72,20 +72,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16061
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -97,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-52-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-52-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -76,20 +76,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16141
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -101,8 +101,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-53-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-53-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -76,20 +76,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16161
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -101,8 +101,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -72,21 +72,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16041
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -97,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL1
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level1
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -72,21 +72,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16061
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -97,8 +97,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-56-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-56-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -78,20 +78,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16141
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -103,8 +103,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-57-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-57-ydk.py
@@ -53,18 +53,18 @@ def config_isis(isis):
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     propagation = af.af_data.propagations.Propagation()
-    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL2
-    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.LEVEL1
+    propagation.source_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level2
+    propagation.destination_level = xr_clns_isis_datatypes.IsisInternalLevelEnum.level1
     propagation.route_policy_name = "LOOPBACKS"
     af.af_data.propagations.propagation.append(propagation)
     # segment routing
@@ -78,20 +78,20 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16161
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -103,8 +103,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-58-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-58-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5002.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -73,21 +73,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16042
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -98,8 +98,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-59-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-59-ydk.py
@@ -47,20 +47,20 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5002.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
     # segment routing
@@ -73,21 +73,21 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     # segment routing
     prefix_sid = interface_af.interface_af_data.PrefixSid()
-    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.ABSOLUTE
+    prefix_sid.type = xr_clns_isis_cfg.IsissidEnum.absolute
     prefix_sid.value = 16062
-    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.ENABLE
-    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.DISABLE
+    prefix_sid.php = xr_clns_isis_cfg.IsisphpFlagEnum.enable
+    explicit_null = xr_clns_isis_cfg.IsisexplicitNullFlagEnum.disable
     prefix_sid.explicit_null = explicit_null
-    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.DISABLE
+    prefix_sid.nflag_clear = xr_clns_isis_cfg.NflagClearEnum.disable
     interface_af.interface_af_data.prefix_sid = prefix_sid
     instance.interfaces.interface.append(interface)
 
@@ -98,8 +98,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV6
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv6
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
@@ -47,23 +47,23 @@ def config_isis(isis):
     instance = isis.instances.Instance()
     instance.instance_name = "DEFAULT"
     instance.running = Empty()
-    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    instance.is_type = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     net = instance.nets.Net()
     net.net_name = "49.0000.1720.1625.5001.00"
     instance.nets.net.append(net)
     isis.instances.instance.append(instance)
     # global address family
     af = instance.afs.Af()
-    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     af.af_data = af.AfData()
     metric_style = af.af_data.metric_styles.MetricStyle()
-    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.NEW_METRIC_STYLE
-    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.NOT_SET
-    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.DISABLED
+    metric_style.style = xr_clns_isis_cfg.IsisMetricStyleEnum.new_metric_style
+    metric_style.level = xr_clns_isis_datatypes.IsisInternalLevelEnum.not_set
+    transition_state = xr_clns_isis_cfg.IsisMetricStyleTransitionEnum.disabled
     metric_style.transition_state = transition_state
     af.af_data.metric_styles.metric_style.append(metric_style)
-    af.af_data.mpls.level = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.LEVEL2
+    af.af_data.mpls.level = xr_clns_isis_cfg.IsisConfigurableLevelsEnum.level2
     af.af_data.mpls.router_id.interface_name = "Loopback0"
     instance.afs.af.append(af)
 
@@ -71,11 +71,11 @@ def config_isis(isis):
     interface = instance.interfaces.Interface()
     interface.interface_name = "Loopback0"
     interface.running = Empty()
-    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.PASSIVE
+    interface.state = xr_clns_isis_cfg.IsisInterfaceStateEnum.passive
     # interface address family
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)
@@ -87,8 +87,8 @@ def config_isis(isis):
     interface.point_to_point = Empty()
     # interface address familiy
     interface_af = interface.interface_afs.InterfaceAf()
-    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.IPV4
-    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.UNICAST
+    interface_af.af_name = xr_clns_isis_datatypes.IsisAddressFamilyEnum.ipv4
+    interface_af.saf_name = xr_clns_isis_datatypes.IsisSubAddressFamilyEnum.unicast
     interface_af.interface_af_data.running = Empty()
     interface.interface_afs.interface_af.append(interface_af)
     instance.interfaces.interface.append(interface)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-20-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # display link status messages for physical links
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DEFAULT
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.default
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-22-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # disable link status messages
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.DISABLE
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.disable
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-24-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_global_interface_configuration(global_interface_configuration):
     """Add config data to global_interface_configuration object."""
     # display link status messages for all interfaces
-    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.SOFTWARE_INTERFACES
+    global_interface_configuration.link_status = xr_ifmgr_cfg.LinkStatusEnumEnum.software_interfaces
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-20-ydk.py
@@ -41,8 +41,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.US
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.us
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.en
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-22-ydk.py
@@ -41,8 +41,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.CN
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.ZH
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.cn
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.zh
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-24-ydk.py
@@ -41,8 +41,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.DE
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.DE
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.de
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.de
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-26-ydk.py
@@ -41,8 +41,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.BR
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.PT
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.br
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.pt
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-28-ydk.py
@@ -41,8 +41,8 @@ import logging
 def config_locale(locale):
     """Add config data to locale object."""
     # country and language configuration
-    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.NG
-    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.EN
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountryEnum.ng
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguageEnum.en
 
 
 if __name__ == "__main__":

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-20-ydk.py
@@ -45,7 +45,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
     peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
     ntp.peer_vrfs.peer_vrf.append(peer_vrf)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
@@ -45,7 +45,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
     peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
     ntp.peer_vrfs.peer_vrf.append(peer_vrf)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-22-ydk.py
@@ -46,7 +46,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv4.source_interface = "Loopback0"
     peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
     peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
@@ -46,7 +46,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv6.source_interface = "Loopback0"
     peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
     peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-24-ydk.py
@@ -46,7 +46,7 @@ def config_ntp(ntp):
     peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
     peer_ipv4.address_ipv4 = "10.0.0.1"
     peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
-    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv4.ntp_version = 4
     peer_type_ipv4.iburst = Empty()
     peer_type_ipv4.preferred_peer = Empty()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
@@ -46,7 +46,7 @@ def config_ntp(ntp):
     peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
     peer_ipv6.address_ipv6 = "2001:db8::a:1"
     peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
-    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.SERVER
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeerEnum.server
     peer_type_ipv6.ntp_version = 4
     peer_type_ipv6.iburst = Empty()
     peer_type_ipv6.preferred_peer = Empty()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
@@ -46,9 +46,9 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -56,9 +56,9 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
@@ -46,8 +46,8 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -55,8 +55,8 @@ def config_rsvp(rsvp):
     interface.name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
@@ -47,10 +47,10 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
     interface.bandwidth.rdm.bc1_bandwidth = 25
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -59,10 +59,10 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 100
     interface.bandwidth.rdm.bc1_bandwidth = 25
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
-    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.PERCENTAGE
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfgEnum.percentage
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
@@ -47,9 +47,9 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
     interface.bandwidth.rdm.bc1_bandwidth = 250000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
     rsvp.interfaces.interface.append(interface)
 
     # RSVP interface gig0/0/0/1
@@ -58,9 +58,9 @@ def config_rsvp(rsvp):
     interface.enable = Empty()
     interface.bandwidth.rdm.bc0_bandwidth = 1000000
     interface.bandwidth.rdm.bc1_bandwidth = 250000
-    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.RDM
-    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.NOT_SPECIFIED
-    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.SUB_POOL
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdmEnum.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0Enum.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1Enum.sub_pool
     rsvp.interfaces.interface.append(interface)
 
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-40-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -72,7 +72,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4 unicast
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_afs = neighbor_group.neighbor_group_afs
     neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-41-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-41-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -72,7 +72,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4 unicast
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_afs = neighbor_group.neighbor_group_afs
     neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-42-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-42-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -72,7 +72,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
     neighbor_group_afs = neighbor_group.neighbor_group_afs

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-43-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-43-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -72,7 +72,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
     neighbor_group_afs = neighbor_group.neighbor_group_afs

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-44-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-44-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -71,7 +71,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV4_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv4_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
     neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-45-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-45-ydk.py
@@ -53,7 +53,7 @@ def config_bgp(bgp):
     four_byte_as.bgp_running = Empty()
     # global address family
     global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
-    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     global_af.enable = Empty()
     four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
     instance_as.four_byte_as.append(four_byte_as)
@@ -71,7 +71,7 @@ def config_bgp(bgp):
     neighbor_groups.neighbor_group.append(neighbor_group)
     # ipv4-unicast address family
     neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
-    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.IPV6_UNICAST
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamilyEnum.ipv6_unicast
     neighbor_group_af.activate = Empty()
     neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
     neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
@@ -62,7 +62,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
 
     # append area/process config

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
@@ -62,7 +62,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -75,7 +75,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
@@ -62,7 +62,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -76,7 +76,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
@@ -62,7 +62,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/0"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -76,7 +76,7 @@ def config_ospf(ospf):
     name_scope = area_area_id.name_scopes.NameScope()
     name_scope.interface_name = "GigabitEthernet0/0/0/1"
     name_scope.running = Empty()
-    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.POINT_TO_POINT
+    name_scope.network_type = xr_ipv4_ospf_cfg.OspfNetworkEnum.point_to_point
     area_area_id.name_scopes.name_scope.append(name_scope)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -63,7 +63,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
 
     # append area/process config

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -63,7 +63,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -76,7 +76,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -63,7 +63,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -77,7 +77,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -63,7 +63,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/0"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 
@@ -77,7 +77,7 @@ def config_ospfv3(ospfv3):
     interface = area_area_id.interfaces.Interface()
     interface.interface_name = "GigabitEthernet0/0/0/1"
     interface.enable = Empty()
-    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.POINT_TO_POINT
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3NetworkEnum.point_to_point
     area_area_id.interfaces.interface.append(interface)
     process.default_vrf.area_addresses.area_area_id.append(area_area_id)
 


### PR DESCRIPTION
As of YDK 0.5.2, enums follow the capitalization used in the YANG model.
Previous versions of YDK were modifying it.