### PR TITLE
Fix reference to OC routing policy types

### DIFF
--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-24-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-24-ydk.py
@@ -32,6 +32,8 @@ from ydk.services import CodecService
 from ydk.providers import CodecServiceProvider
 from ydk.models.openconfig import openconfig_routing_policy \
     as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
 from ydk.types import Empty
 import logging
 
@@ -62,7 +64,7 @@ def config_routing_policy(routing_policy):
     bgp_conditions = statement.conditions.bgp_conditions
     match_community_set = bgp_conditions.MatchCommunitySet()
     match_community_set.community_set = "COMMUNITY-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ALL
+    match_set_options = oc_policy_types.MatchSetOptionsTypeEnum.ALL
     match_community_set.match_set_options = match_set_options
     bgp_conditions.match_community_set = match_community_set
     statement.actions.accept_route = Empty()
@@ -73,7 +75,7 @@ def config_routing_policy(routing_policy):
     bgp_conditions = statement.conditions.bgp_conditions
     match_as_path_set = bgp_conditions.MatchAsPathSet()
     match_as_path_set.as_path_set = "AS-PATH-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ANY
+    match_set_options = oc_policy_types.MatchSetOptionsTypeEnum.ANY
     match_as_path_set.match_set_options = match_set_options
     bgp_conditions.match_as_path_set = match_as_path_set
     statement.actions.bgp_actions.set_local_pref = 50

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-26-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-26-ydk.py
@@ -32,6 +32,8 @@ from ydk.services import CodecService
 from ydk.providers import CodecServiceProvider
 from ydk.models.openconfig import openconfig_routing_policy \
     as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
 from ydk.types import Empty
 import logging
 
@@ -66,7 +68,7 @@ def config_routing_policy(routing_policy):
     statement.name = "prefix-set1"
     match_prefix_set = statement.conditions.MatchPrefixSet()
     match_prefix_set.prefix_set = "PREFIX-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsRestrictedTypeEnum.ANY
+    match_set_options = oc_policy_types.MatchSetOptionsRestrictedTypeEnum.ANY
     match_prefix_set.match_set_options = match_set_options
     statement.conditions.match_prefix_set = match_prefix_set
     statement.actions.bgp_actions.set_local_pref = 1000

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-24-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-24-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_routing_policy \
     as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
 from ydk.types import Empty
 import logging
 
@@ -65,7 +67,7 @@ def config_routing_policy(routing_policy):
     bgp_conditions = statement.conditions.bgp_conditions
     match_community_set = bgp_conditions.MatchCommunitySet()
     match_community_set.community_set = "COMMUNITY-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ALL
+    match_set_options = oc_policy_types.MatchSetOptionsTypeEnum.ALL
     match_community_set.match_set_options = match_set_options
     bgp_conditions.match_community_set = match_community_set
     statement.actions.accept_route = Empty()
@@ -76,7 +78,7 @@ def config_routing_policy(routing_policy):
     bgp_conditions = statement.conditions.bgp_conditions
     match_as_path_set = bgp_conditions.MatchAsPathSet()
     match_as_path_set.as_path_set = "AS-PATH-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ANY
+    match_set_options = oc_policy_types.MatchSetOptionsTypeEnum.ANY
     match_as_path_set.match_set_options = match_set_options
     bgp_conditions.match_as_path_set = match_as_path_set
     statement.actions.bgp_actions.set_local_pref = 50

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-26-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-26-ydk.py
@@ -35,6 +35,8 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.openconfig import openconfig_routing_policy \
     as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
 from ydk.types import Empty
 import logging
 
@@ -69,7 +71,7 @@ def config_routing_policy(routing_policy):
     statement.name = "prefix-set1"
     match_prefix_set = statement.conditions.MatchPrefixSet()
     match_prefix_set.prefix_set = "PREFIX-SET1"
-    match_set_options = oc_routing_policy.MatchSetOptionsRestrictedTypeEnum.ANY
+    match_set_options = oc_policy_types.MatchSetOptionsRestrictedTypeEnum.ANY
     match_prefix_set.match_set_options = match_set_options
     statement.conditions.match_prefix_set = match_prefix_set
     statement.actions.bgp_actions.set_local_pref = 1000


### PR DESCRIPTION
Types for match-set-options are now defined in a separate module
openconfig_policy_types instead of module openconfig_routing_policy.