### PR TITLE
Add sample apps to execute rollback-cfg-last RPC

### DIFF
--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Execute RPC for model Cisco-IOS-XR-cfgmgr-rollback-act.
+
+usage: nc-execute-xr-cfgmgr-rollback-act-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import ExecutorService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
+    as xr_cfgmgr_rollback_act
+import logging
+
+
+def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
+    """Add RPC input data to roll_back_configuration_last_rpc object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create executor service
+    executor = ExecutorService()
+
+    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
+    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+
+    # execute RPC on NETCONF device
+    # executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Execute RPC for model Cisco-IOS-XR-cfgmgr-rollback-act.
+
+usage: nc-execute-xr-cfgmgr-rollback-act-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import ExecutorService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
+    as xr_cfgmgr_rollback_act
+import logging
+
+
+def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
+    """Add RPC input data to roll_back_configuration_last_rpc object."""
+    # roll back most recent change
+    roll_back_configuration_last_rpc.input.count = 1
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create executor service
+    executor = ExecutorService()
+
+    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
+    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+
+    # execute RPC on NETCONF device
+    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.xml
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.xml
@@ -1,0 +1,4 @@
+<roll-back-configuration-last xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cfgmgr-rollback-act">
+  <count>1</count>
+</roll-back-configuration-last>
+

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Execute RPC for model Cisco-IOS-XR-cfgmgr-rollback-act.
+
+usage: nc-execute-xr-cfgmgr-rollback-act-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import ExecutorService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
+    as xr_cfgmgr_rollback_act
+import logging
+
+
+def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
+    """Add RPC input data to roll_back_configuration_last_rpc object."""
+    # roll back the two most recent changes
+    roll_back_configuration_last_rpc.input.comment = "Simple programmatic rollback"
+    roll_back_configuration_last_rpc.input.count = 2
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create executor service
+    executor = ExecutorService()
+
+    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
+    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+
+    # execute RPC on NETCONF device
+    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.xml
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.xml
@@ -1,0 +1,5 @@
+<roll-back-configuration-last xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cfgmgr-rollback-act">
+  <count>2</count>
+  <comment>Simple programmatic rollback</comment>
+</roll-back-configuration-last>
+

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Execute RPC for model Cisco-IOS-XR-cfgmgr-rollback-act.
+
+usage: nc-execute-xr-cfgmgr-rollback-act-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import ExecutorService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
+    as xr_cfgmgr_rollback_act
+import logging
+
+
+def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
+    """Add RPC input data to roll_back_configuration_last_rpc object."""
+    # force roll back for the five most recent changes
+    roll_back_configuration_last_rpc.input.comment = "Forced programmatic rollback"
+    roll_back_configuration_last_rpc.input.count = 5
+    roll_back_configuration_last_rpc.input.force = True
+    roll_back_configuration_last_rpc.input.label = "PRB-005"
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create executor service
+    executor = ExecutorService()
+
+    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
+    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+
+    # execute RPC on NETCONF device
+    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.xml
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.xml
@@ -1,0 +1,6 @@
+<roll-back-configuration-last xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cfgmgr-rollback-act">
+  <count>5</count>
+  <force>true</force>
+  <label>PRB-005</label>
+  <comment>Forced programmatic rollback</comment>
+</roll-back-configuration-last>


### PR DESCRIPTION
Includes one boilerplate app and three custom apps to rollback the last
configuration changes:
nc-execute-xr-cfgmgr-rollback-act-10-ydk.py - execute boilerplate
nc-execute-xr-cfgmgr-rollback-act-20-ydk.py - rollback last 1
nc-execute-xr-cfgmgr-rollback-act-22-ydk.py - commented rollback last 2
nc-execute-xr-cfgmgr-rollback-act-24-ydk.py - forced rollback last 5
These apps use the executor service which executes RPCs defined in a
YANG model.  These RPCs are generally called actions in the context of
XR YANG models and commands in the context of XR CLI.