### PR TITLE
Update gitignore to ignore project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 test
-TODO*
 samples/intermediate
+projects/*
+!projects/README.md
 .vagrant/
+TODO*


### PR DESCRIPTION
Make sure that all entries under the projects directory are ignored with
the exception of README.md.  That directory is meant to be a working
directory for users of the Vagrant box.