### PR TITLE
Add boilerplate apps for IP explicit path config

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-create-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-create-xr-ip-iep-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-iep-cfg.
+
+usage: nc-create-xr-ip-iep-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_iep_cfg \
+    as xr_ip_iep_cfg
+import logging
+
+
+def config_ip_explicit_paths(ip_explicit_paths):
+    """Add config data to ip_explicit_paths object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_explicit_paths = xr_ip_iep_cfg.IpExplicitPaths()  # create object
+    config_ip_explicit_paths(ip_explicit_paths)  # add object configuration
+
+    # create configuration on NETCONF device
+    # crud.create(provider, ip_explicit_paths)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-delete-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-delete-xr-ip-iep-cfg-10-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-iep-cfg.
+
+usage: nc-delete-xr-ip-iep-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_iep_cfg \
+    as xr_ip_iep_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_explicit_paths = xr_ip_iep_cfg.IpExplicitPaths()  # create object
+
+    # delete configuration on NETCONF device
+    # crud.delete(provider, ip_explicit_paths)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-read-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-read-xr-ip-iep-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-iep-cfg.
+
+usage: nc-read-xr-ip-iep-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_iep_cfg \
+    as xr_ip_iep_cfg
+import logging
+
+
+def process_ip_explicit_paths(ip_explicit_paths):
+    """Process data in ip_explicit_paths object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_explicit_paths = xr_ip_iep_cfg.IpExplicitPaths()  # create object
+
+    # read data from NETCONF device
+    # ip_explicit_paths = crud.read(provider, ip_explicit_paths)
+    process_ip_explicit_paths(ip_explicit_paths)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-update-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-update-xr-ip-iep-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-iep-cfg.
+
+usage: nc-update-xr-ip-iep-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_iep_cfg \
+    as xr_ip_iep_cfg
+import logging
+
+
+def config_ip_explicit_paths(ip_explicit_paths):
+    """Add config data to ip_explicit_paths object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_explicit_paths = xr_ip_iep_cfg.IpExplicitPaths()  # create object
+    config_ip_explicit_paths(ip_explicit_paths)  # add object configuration
+
+    # update configuration on NETCONF device
+    # crud.update(provider, ip_explicit_paths)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps to configure IP explicit paths (e.g.
strict, loose, exclude, etc):
nc-create-xr-ip-iep-cfg-10-ydk.py - create boilerplate
nc-delete-xr-ip-iep-cfg-10-ydk.py - delete boilerplate
nc-read-xr-ip-iep-cfg-10-ydk.py   - read boilerplate
nc-update-xr-ip-iep-cfg-10-ydk.py - update boilerplate