### PR TITLE
Add basic apps for banner configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.exec_
+    banner.banner_text = ";\n" \
+                         "----------------------\n" \
+                         " EXEC process created\n" \
+                         "----------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner exec ;
+----------------------
+ EXEC process created
+----------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>exec</banner-name>
+    <banner-text>;
+----------------------
+ EXEC process created
+----------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.incoming
+    banner.banner_text = ";\n" \
+                         "----------------------------------------------" \
+                         "---------------------\n" \
+                         " Incoming connection to a terminal line from a" \
+                         " host on the network\n" \
+                         "----------------------------------------------" \
+                         "---------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner incoming ;
+-------------------------------------------------------------------
+ Incoming connection to a terminal line from a host on the network
+-------------------------------------------------------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>incoming</banner-name>
+    <banner-text>;
+-------------------------------------------------------------------
+ Incoming connection to a terminal line from a host on the network
+-------------------------------------------------------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.motd
+    banner.banner_text = ";\n" \
+                         "--------------------\n" \
+                         " Message of the day\n" \
+                         "--------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner motd ;
+--------------------
+ Message of the day
+--------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>motd</banner-name>
+    <banner-text>;
+--------------------
+ Message of the day
+--------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.login
+    banner.banner_text = ";\n" \
+                         "----------------------\n" \
+                         " Device login message\n" \
+                         "----------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner login ;
+----------------------
+ Device login message
+----------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>login</banner-name>
+    <banner-text>;
+----------------------
+ Device login message
+----------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.slip_ppp
+    banner.banner_text = ";\n" \
+                         "----------------------------------\n" \
+                         " Message for SLIP/PPP connections\n" \
+                         "----------------------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner slip-ppp ;
+----------------------------------
+ Message for SLIP/PPP connections
+----------------------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>slip-ppp</banner-name>
+    <banner-text>;
+----------------------------------
+ Message for SLIP/PPP connections
+----------------------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-create-xr-infra-infra-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+def config_banners(banners):
+    """Add config data to banners object."""
+    banner = banners.Banner()
+    banner.banner_name = xr_infra_infra_cfg.BannerEnum.prompt_timeout
+    banner.banner_text = ";\n" \
+                         "------------------------------------------\n" \
+                         " Message for login authentication timeout\n" \
+                         "------------------------------------------\n" \
+                         ";\n"
+    banners.banner.append(banner)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+    config_banners(banners)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, banners)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.2
+banner prompt-timeout ;
+------------------------------------------
+ Message for login authentication timeout
+------------------------------------------
+;
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.xml
@@ -1,0 +1,12 @@
+<banners xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg">
+  <banner>
+    <banner-name>prompt-timeout</banner-name>
+    <banner-text>;
+------------------------------------------
+ Message for login authentication timeout
+------------------------------------------
+;
+</banner-text>
+  </banner>
+</banners>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-20-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-infra-cfg.
+
+usage: nc-delete-xr-infra-infra-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_cfg \
+    as xr_infra_infra_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    banners = xr_infra_infra_cfg.Banners()  # create object
+
+    # delete configuration on NETCONF device
+    crud.delete(provider, banners)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes seven custom apps to create and delete banner configuration
(exec, incoming, motd, login, slip-ppp, prompt-timeout):
nc-create-xr-infra-infra-cfg-20-ydk.py - Exec banner
nc-create-xr-infra-infra-cfg-21-ydk.py - Incoming banner
nc-create-xr-infra-infra-cfg-22-ydk.py - MOTD banner
nc-create-xr-infra-infra-cfg-23-ydk.py - Login banner
nc-create-xr-infra-infra-cfg-24-ydk.py - SLIP/PPP banner
nc-create-xr-infra-infra-cfg-25-ydk.py - Prompt timeout banner
nc-delete-xr-infra-infra-cfg-20-ydk.py - delete all banners