### PR TITLE
Add sample apps to encode user name configuration

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-aaa-lib-cfg.
+
+usage: cd-encode-xr-aaa-lib-cfg-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_aaa_lib_cfg \
+    as xr_aaa_lib_cfg
+import logging
+
+
+def config_aaa(aaa):
+    """Add config data to aaa object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    aaa = xr_aaa_lib_cfg.Aaa()  # create object
+    config_aaa(aaa)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, aaa))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-aaa-lib-cfg.
+
+usage: cd-encode-xr-aaa-lib-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_aaa_lib_cfg \
+    as xr_aaa_lib_cfg
+import logging
+
+
+def config_aaa(aaa):
+    """Add config data to aaa object."""
+    username = aaa.usernames.Username()
+    username.ordering_index = 20
+    username.name = "sysadmin"
+    username.secret = "$1$AQ9U$6iYrri084f6crrBmPeN0q."
+    # task group
+    usergroup_under_username = username.usergroup_under_usernames.UsergroupUnderUsername()
+    usergroup_under_username.name = "sysadmin"
+    username.usergroup_under_usernames.usergroup_under_username.append(usergroup_under_username)
+    aaa.usernames.username.append(username)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    aaa = xr_aaa_lib_cfg.Aaa()  # create object
+    config_aaa(aaa)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, aaa))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.xml
@@ -1,0 +1,15 @@
+<aaa xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-lib-cfg">
+  <usernames xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-locald-cfg">
+    <username>
+      <name>sysadmin</name>
+      <ordering-index>20</ordering-index>
+      <secret>$1$AQ9U$6iYrri084f6crrBmPeN0q.</secret>
+      <usergroup-under-usernames>
+        <usergroup-under-username>
+          <name>sysadmin</name>
+        </usergroup-under-username>
+      </usergroup-under-usernames>
+    </username>
+  </usernames>
+</aaa>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-aaa-lib-cfg.
+
+usage: cd-encode-xr-aaa-lib-cfg-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_aaa_lib_cfg \
+    as xr_aaa_lib_cfg
+import logging
+
+
+def config_aaa(aaa):
+    """Add config data to aaa object."""
+    username = aaa.usernames.Username()
+    username.ordering_index = 22
+    username.name = "netop"
+    username.secret = "$1$Z/8E$GDBQs1PtqJnwlQ9kKGpXj/"
+    # task group
+    usergroup_under_username = username.usergroup_under_usernames.UsergroupUnderUsername()
+    usergroup_under_username.name = "netadmin"
+    username.usergroup_under_usernames.usergroup_under_username.append(usergroup_under_username)
+    # task group
+    usergroup_under_username = username.usergroup_under_usernames.UsergroupUnderUsername()
+    usergroup_under_username.name = "operator"
+    username.usergroup_under_usernames.usergroup_under_username.append(usergroup_under_username)
+    aaa.usernames.username.append(username)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    aaa = xr_aaa_lib_cfg.Aaa()  # create object
+    config_aaa(aaa)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, aaa))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.xml
@@ -1,0 +1,18 @@
+<aaa xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-lib-cfg">
+  <usernames xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-locald-cfg">
+    <username>
+      <name>netop</name>
+      <ordering-index>22</ordering-index>
+      <secret>$1$Z/8E$GDBQs1PtqJnwlQ9kKGpXj/</secret>
+      <usergroup-under-usernames>
+        <usergroup-under-username>
+          <name>netadmin</name>
+        </usergroup-under-username>
+        <usergroup-under-username>
+          <name>operator</name>
+        </usergroup-under-username>
+      </usergroup-under-usernames>
+    </username>
+  </usernames>
+</aaa>
+


### PR DESCRIPTION
Includes one boilerplate app and two custom apps to configure local
user names:
cd-encode-xr-aaa-lib-cfg-10-ydk.py - encode boilerplate
cd-encode-xr-aaa-lib-cfg-20-ydk.py - user w/one task group
cd-encode-xr-aaa-lib-cfg-22-ydk.py - user w/two task groups