### PR TITLE
Add process start to OSPFv2 sample apps

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
@@ -42,6 +42,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.xml
@@ -23,6 +23,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
@@ -42,6 +42,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.xml
@@ -34,6 +34,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
@@ -42,6 +42,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
@@ -42,6 +42,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
@@ -45,6 +45,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.xml
@@ -23,6 +23,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
@@ -45,6 +45,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.xml
@@ -34,6 +34,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
@@ -45,6 +45,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
@@ -45,6 +45,7 @@ def config_ospf(ospf):
     process = ospf.processes.Process()
     process.process_name = "DEFAULT"
     process.default_vrf.router_id = "172.16.255.1"
+    process.start = Empty()
 
     # Area 0
     area_area_id = process.default_vrf.area_addresses.AreaAreaId()

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.xml
@@ -35,6 +35,7 @@
         </area-addresses>
         <router-id>172.16.255.1</router-id>
       </default-vrf>
+      <start></start>
     </process>
   </processes>
 </ospf>


### PR DESCRIPTION
OSPFv2 sample apps were missing the `start` attribute under the process object. That attribute is required for proper protocol configuration.

