### PR TITLE
Add sample apps to encode ARP config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: cd-encode-xr-ipv4-arp-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import logging
+
+
+def config_arp(arp):
+    """Add config data to arp object."""
+    arp.outer_cos = 5
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+    config_arp(arp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, arp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.txt
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.txt
@@ -1,0 +1,2 @@
+arp outer-cos 5
+end

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.xml
@@ -1,0 +1,4 @@
+<arp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-cfg">
+  <outer-cos>5</outer-cos>
+</arp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: cd-encode-xr-ipv4-arp-cfg-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import logging
+
+
+def config_arp(arp):
+    """Add config data to arp object."""
+    arp.inner_cos = 4
+    arp.outer_cos = 5
+    arp.max_entries = 1000
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+    config_arp(arp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, arp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.txt
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+arp inner-cos 4
+arp outer-cos 5
+arp max-entries 1000
+end

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.xml
@@ -1,0 +1,6 @@
+<arp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-cfg">
+  <inner-cos>4</inner-cos>
+  <max-entries>1000</max-entries>
+  <outer-cos>5</outer-cos>
+</arp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: cd-encode-xr-ipv4-arp-cfg-30-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import logging
+
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "default"
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncapEnum.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntryEnum.static
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, arpgmp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.txt
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf default 172.16.0.1 5254.0028.8988 ARPA
+end

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.xml
@@ -1,0 +1,14 @@
+<arpgmp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-cfg">
+  <vrf>
+    <vrf-name>default</vrf-name>
+    <entries>
+      <entry>
+        <address>172.16.0.1</address>
+        <encapsulation>arpa</encapsulation>
+        <entry-type>static</entry-type>
+        <mac-address>52:54:00:28:89:88</mac-address>
+      </entry>
+    </entries>
+  </vrf>
+</arpgmp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: cd-encode-xr-ipv4-arp-cfg-32-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import logging
+
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "default"
+
+    # arp entry for 172.16.0.1
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncapEnum.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntryEnum.static
+    vrf.entries.entry.append(entry)
+
+    # arp entry for 172.16.0.4
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.4"
+    entry.mac_address = "52:54:00:7d:8f:8f"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncapEnum.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntryEnum.static
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, arpgmp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.txt
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf default 172.16.0.1 5254.0028.8988 ARPA
+arp vrf default 172.16.0.4 5254.007d.8f8f ARPA
+end

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.xml
@@ -1,0 +1,20 @@
+<arpgmp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-cfg">
+  <vrf>
+    <vrf-name>default</vrf-name>
+    <entries>
+      <entry>
+        <address>172.16.0.1</address>
+        <encapsulation>arpa</encapsulation>
+        <entry-type>static</entry-type>
+        <mac-address>52:54:00:28:89:88</mac-address>
+      </entry>
+      <entry>
+        <address>172.16.0.4</address>
+        <encapsulation>arpa</encapsulation>
+        <entry-type>static</entry-type>
+        <mac-address>52:54:00:7d:8f:8f</mac-address>
+      </entry>
+    </entries>
+  </vrf>
+</arpgmp>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: cd-encode-xr-ipv4-arp-cfg-34-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import logging
+
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "RED"
+
+    # arp entry for 172.16.0.1
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncapEnum.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntryEnum.static
+    entry.interface = "GigabitEthernet0/0/0/0"
+    vrf.entries.entry.append(entry)
+
+    # arp entry for 172.16.0.4
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.4"
+    entry.mac_address = "52:54:00:7d:8f:8f"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncapEnum.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntryEnum.static
+    entry.interface = "GigabitEthernet0/0/0/1"
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, arpgmp))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.txt
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf RED 172.16.0.1 5254.0028.8988 ARPA interface GigabitEthernet0/0/0/0
+arp vrf RED 172.16.0.4 5254.007d.8f8f ARPA interface GigabitEthernet0/0/0/1
+end
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.xml
@@ -1,0 +1,22 @@
+<arpgmp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-cfg">
+  <vrf>
+    <vrf-name>RED</vrf-name>
+    <entries>
+      <entry>
+        <address>172.16.0.1</address>
+        <encapsulation>arpa</encapsulation>
+        <entry-type>static</entry-type>
+        <interface>GigabitEthernet0/0/0/0</interface>
+        <mac-address>52:54:00:28:89:88</mac-address>
+      </entry>
+      <entry>
+        <address>172.16.0.4</address>
+        <encapsulation>arpa</encapsulation>
+        <entry-type>static</entry-type>
+        <interface>GigabitEthernet0/0/0/1</interface>
+        <mac-address>52:54:00:7d:8f:8f</mac-address>
+      </entry>
+    </entries>
+  </vrf>
+</arpgmp>
+


### PR DESCRIPTION
Includes five custom apps to encode the ARP config:
cd-encode-xr-ipv4-arp-cfg-20-ydk.py - Global with cos
cd-encode-xr-ipv4-arp-cfg-22-ydk.py - Global with cos and max entries
cd-encode-xr-ipv4-arp-cfg-30-ydk.py - Single static arp entry
cd-encode-xr-ipv4-arp-cfg-32-ydk.py - Multiple static arp entries
cd-encode-xr-ipv4-arp-cfg-34-ydk.py - Multiple static arp entries w/vrf