### PR TITLE
Add sample apps to configure log/debug timestamps

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    # crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_timestamp_disable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log disable
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.xml
@@ -1,0 +1,8 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-timestamp-disable></log-timestamp-disable>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_uptime = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log uptime
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.xml
@@ -1,0 +1,8 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-uptime></log-uptime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime 
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.xml
@@ -1,0 +1,12 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <time-stamp-value>enable</time-stamp-value>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime msec
+service timestamps debug datetime localtime msec
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.xml
@@ -1,0 +1,21 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <debug>
+      <debug-datetime>
+        <datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+        </datetime-value>
+      </debug-datetime>
+    </debug>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.year = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.year = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime msec show-timezone year
+service timestamps debug datetime localtime msec show-timezone year
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.xml
@@ -1,0 +1,25 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <debug>
+      <debug-datetime>
+        <datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+          <time-zone>enable</time-zone>
+          <year>enable</year>
+        </datetime-value>
+      </debug-datetime>
+    </debug>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+          <time-zone>enable</time-zone>
+          <year>enable</year>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-delete-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+
+    # delete configuration on NETCONF device
+    # crud.delete(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-20-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-delete-xr-infra-syslog-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+
+    # delete configuration on NETCONF device
+    crud.delete(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-read-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def process_syslog_service(syslog_service):
+    """Process data in syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+
+    # read data from NETCONF device
+    # syslog_service = crud.read(provider, syslog_service)
+    process_syslog_service(syslog_service)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-update-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # update configuration on NETCONF device
+    # crud.update(provider, syslog_service)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate and six custom apps to configure syslog and
debug timestamps:
nc-create-xr-infra-syslog-cfg-20-ydk.py - Disable log timestamps
nc-create-xr-infra-syslog-cfg-22-ydk.py - Uptime log timestamps
nc-create-xr-infra-syslog-cfg-24-ydk.py - Local time log timestamps
nc-create-xr-infra-syslog-cfg-26-ydk.py - Local time log/debug timest.
nc-create-xr-infra-syslog-cfg-28-ydk.py - Detailed log/debug timestamp
nc-delete-xr-infra-syslog-cfg-20-ydk.py - Delete all timestamp config