### PR TITLE
Add sample apps for encoding log/debug timestamps

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import logging
+
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_timestamp_disable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.xml
@@ -1,0 +1,8 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-timestamp-disable></log-timestamp-disable>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import logging
+
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_uptime = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.xml
@@ -1,0 +1,8 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-uptime></log-uptime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.xml
@@ -1,0 +1,12 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <time-stamp-value>enable</time-stamp-value>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.xml
@@ -1,0 +1,21 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <debug>
+      <debug-datetime>
+        <datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+        </datetime-value>
+      </debug-datetime>
+    </debug>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.year = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfoEnum.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.year = xr_infra_syslog_cfg.TimeInfoEnum.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog_service))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.xml
@@ -1,0 +1,25 @@
+<syslog-service xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <timestamps>
+    <debug>
+      <debug-datetime>
+        <datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+          <time-zone>enable</time-zone>
+          <year>enable</year>
+        </datetime-value>
+      </debug-datetime>
+    </debug>
+    <log>
+      <log-datetime>
+        <log-datetime-value>
+          <msec>enable</msec>
+          <time-stamp-value>enable</time-stamp-value>
+          <time-zone>enable</time-zone>
+          <year>enable</year>
+        </log-datetime-value>
+      </log-datetime>
+    </log>
+  </timestamps>
+</syslog-service>
+


### PR DESCRIPTION
Includes one boilerplate app and five custom apps to encode log/debug
timestamps in XML:
cd-encode-xr-infra-syslog-cfg-10-ydk.py - encode boilerplate
cd-encode-xr-infra-syslog-cfg-20-ydk.py - Disable log timestamps
cd-encode-xr-infra-syslog-cfg-22-ydk.py - Uptime log timestamps
cd-encode-xr-infra-syslog-cfg-24-ydk.py - Local time log timestamps
cd-encode-xr-infra-syslog-cfg-26-ydk.py - Local time log/debug timest.
cd-encode-xr-infra-syslog-cfg-28-ydk.py - Detailed log/debug timestamp