### PR TITLE
Add sample apps to configure local logging

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # create configuration on NETCONF device
+    # crud.create(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.console_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+logging console disable
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.xml
@@ -1,0 +1,6 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <console-logging>
+    <logging-level>disable</logging-level>
+  </console-logging>
+</syslog>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.console_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    syslog.monitor_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    syslog.buffered_logging.buffer_size = 125000000
+    syslog.buffered_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.info
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.2.1
+logging console disable
+logging monitor disable
+logging buffered 125000000
+logging buffered informational
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.xml
@@ -1,0 +1,13 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <buffered-logging>
+    <buffer-size>125000000</buffer-size>
+    <logging-level>info</logging-level>
+  </buffered-logging>
+  <console-logging>
+    <logging-level>disable</logging-level>
+  </console-logging>
+  <monitor-logging>
+    <logging-level>disable</logging-level>
+  </monitor-logging>
+</syslog>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.archive.device = '/disk1:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverityEnum.debug
+    syslog.archive.frequency = xr_infra_syslog_cfg.LogCollectFrequencyEnum.daily
+    syslog.archive.size = 32
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.2.1
+logging archive
+ device disk1
+ severity debugging
+ frequency daily
+ archive-size 32
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.xml
@@ -1,0 +1,9 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <archive>
+    <device>/disk1:</device>
+    <frequency>daily</frequency>
+    <severity>debug</severity>
+    <size>32</size>
+  </archive>
+</syslog>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-create-xr-infra-syslog-cfg-42-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.archive.device = '/harddisk:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverityEnum.informational
+    syslog.archive.file_size = 10
+    syslog.archive.size = 100
+    syslog.archive.length = 52
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+logging archive
+ device harddisk
+ severity informational
+ file-size 10
+ archive-size 100
+ archive-length 52
+!
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.xml
@@ -1,0 +1,10 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <archive>
+    <device>/harddisk:</device>
+    <file-size>10</file-size>
+    <length>52</length>
+    <severity>informational</severity>
+    <size>100</size>
+  </archive>
+</syslog>
+

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-delete-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+
+    # delete configuration on NETCONF device
+    # crud.delete(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-30-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-delete-xr-infra-syslog-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+def config_syslog(syslog):
+  syslog.enable_console_logging=False
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)
+    # delete configuration on NETCONF device
+    crud.delete(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-read-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def process_syslog(syslog):
+    """Process data in syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+
+    # read data from NETCONF device
+    # syslog = crud.read(provider, syslog)
+    process_syslog(syslog)  # process object data
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: nc-update-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # update configuration on NETCONF device
+    # crud.update(provider, syslog)
+
+    provider.close()
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplates and five custom apps to configure syslog for
local logging:
nc-create-xr-infra-syslog-cfg-30-ydk.py - Logging console disable
nc-create-xr-infra-syslog-cfg-32-ydk.py - Logging buffered
nc-create-xr-infra-syslog-cfg-40-ydk.py - Logging archive disk1
nc-create-xr-infra-syslog-cfg-42-ydk.py - Logging archive harddisk
nc-delete-xr-infra-syslog-cfg-30-ydk.py - Delete all logging config