### PR TITLE
Add sample apps for encoding local logging config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-11-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, syslog))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-30-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog_service object."""
+    syslog.console_logging.logging_level=xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.xml
@@ -1,0 +1,6 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <console-logging>
+    <logging-level>disable</logging-level>
+  </console-logging>
+</syslog>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-32-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog_service object."""
+    syslog.console_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    syslog.monitor_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.disable
+    syslog.buffered_logging.buffer_size = 125000000
+    syslog.buffered_logging.logging_level = xr_infra_syslog_cfg.LoggingLevelsEnum.info
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.xml
@@ -1,0 +1,13 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <buffered-logging>
+    <buffer-size>125000000</buffer-size>
+    <logging-level>info</logging-level>
+  </buffered-logging>
+  <console-logging>
+    <logging-level>disable</logging-level>
+  </console-logging>
+  <monitor-logging>
+    <logging-level>disable</logging-level>
+  </monitor-logging>
+</syslog>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-40-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog_service object."""
+    syslog.archive.device = '/disk1:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverityEnum.debug
+    syslog.archive.frequency = xr_infra_syslog_cfg.LogCollectFrequencyEnum.daily
+    syslog.archive.size = 32
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.xml
@@ -1,0 +1,9 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <archive>
+    <device>/disk1:</device>
+    <frequency>daily</frequency>
+    <severity>debug</severity>
+    <size>32</size>
+  </archive>
+</syslog>
+

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: cd-encode-xr-infra-syslog-cfg-42-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import logging
+
+
+def config_syslog(syslog):
+    """Add config data to syslog_service object."""
+    syslog.archive.device = '/harddisk:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverityEnum.informational
+    syslog.archive.file_size = 10
+    syslog.archive.size = 100
+    syslog.archive.length = 52
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, syslog))
+
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.xml
@@ -1,0 +1,10 @@
+<syslog xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg">
+  <archive>
+    <device>/harddisk:</device>
+    <file-size>10</file-size>
+    <length>52</length>
+    <severity>informational</severity>
+    <size>100</size>
+  </archive>
+</syslog>
+


### PR DESCRIPTION
Includes one boilerplate app and four custom apps to encode config for
syslog local logging in XML:
cd-encode-xr-infra-syslog-cfg-11-ydk.py
cd-encode-xr-infra-syslog-cfg-30-ydk.py
cd-encode-xr-infra-syslog-cfg-32-ydk.py
cd-encode-xr-infra-syslog-cfg-40-ydk.py
cd-encode-xr-infra-syslog-cfg-42-ydk.py