### PR TITLE
Change logging level to INFO for basic apps

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-20-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/cd-encode-xr-aaa-lib-cfg-22-ydk.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-20-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/cd-encode-xr-cdp-cfg-24-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-20-ydk.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-21-ydk.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-30-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-31-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-31-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-32-ydk.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-33-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-33-ydk.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-34-ydk.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-35-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-35-ydk.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-40-ydk.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-41-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-41-ydk.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-52-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-52-ydk.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-53-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-53-ydk.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-54-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-54-ydk.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-55-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-55-ydk.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-56-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-56-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-57-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-57-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-58-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-58-ydk.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-59-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-59-ydk.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-60-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/cd-encode-xr-clns-isis-cfg-60-ydk.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/cd-encode-xr-crypto-macsec-mka-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/cd-encode-xr-crypto-macsec-mka-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-20-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/cd-encode-xr-ethernet-lldp-cfg-24-ydk.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-11-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-11-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-22-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-24-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-30-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-32-ydk.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-34-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-36-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/cd-encode-xr-ifmgr-cfg-36-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-22-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-24-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-26-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/cd-encode-xr-infra-infra-clock-linux-cfg-28-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-20-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-24-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-26-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/cd-encode-xr-infra-infra-locale-cfg-28-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-20-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/cd-encode-xr-infra-rsi-cfg-21-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-11-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-20-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-24-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-26-ydk.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-28-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-30-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-32-ydk.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-40-ydk.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-42-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-50-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-50-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-51-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-51-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-52-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-52-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-53-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-53-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-60-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-60-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-62-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/cd-encode-xr-infra-syslog-cfg-62-ydk.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-20-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-21-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-22-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-23-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-24-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-25-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-25-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-30-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-31-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-31-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-32-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-33-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-33-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-34-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-35-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-35-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/cd-encode-xr-ip-domain-cfg-40-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-20-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-21-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-22-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-23-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-24-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/cd-encode-xr-ip-ntp-cfg-25-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-20-ydk.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-22-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-24-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-26-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/cd-encode-xr-ip-rsvp-cfg-28-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-20-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-21-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-22-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-23-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-24-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-25-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/cd-encode-xr-ip-static-cfg-25-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-20-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-22-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-30-ydk.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-32-ydk.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-34-ydk.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-80-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-80-ydk.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-82-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-82-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-84-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-84-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-86-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/cd-encode-xr-ipv4-acl-cfg-86-ydk.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-11-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-12-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-20-ydk.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-30-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-32-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/cd-encode-xr-ipv4-arp-cfg-34-ydk.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-11-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-11-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-40-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-40-ydk.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-41-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-41-ydk.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-42-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-42-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-43-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-43-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-44-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-44-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-45-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/cd-encode-xr-ipv4-bgp-cfg-45-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-20-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-30-ydk.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-32-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/cd-encode-xr-ipv4-ospf-cfg-34-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/cd-encode-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-cfg/cd-encode-xr-lib-keychain-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-cfg/cd-encode-xr-lib-keychain-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-20-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-22-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/cd-encode-xr-lib-keychain-macsec-cfg-24-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-21-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-22-ydk.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-23-ydk.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-24-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-25-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/cd-encode-xr-man-ems-cfg-25-ydk.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-20-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-22-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-24-ydk.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-26-ydk.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/cd-encode-xr-policy-repository-cfg-28-ydk.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-21-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-22-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/cd-encode-xr-segment-routing-ms-cfg-23-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/cd-encode-xr-shellutil-cfg-20-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-20-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-22-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-22-ydk.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-24-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-24-ydk.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-26-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-26-ydk.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-28-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-28-ydk.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-30-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-32-ydk.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/cd-encode-xr-telemetry-model-driven-cfg-34-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-10-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-10-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-22-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-24-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-24-ydk.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-26-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-26-ydk.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-28-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-routing-policy/cd-encode-oc-routing-policy-28-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-10-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-10-ydk.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-30-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-30-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-32-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-32-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-34-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-telemetry/cd-encode-oc-telemetry-34-ydk.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-20-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-create-xr-aaa-lib-cfg-22-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-delete-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-delete-xr-aaa-lib-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-delete-xr-aaa-lib-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-delete-xr-aaa-lib-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-read-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-read-xr-aaa-lib-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-update-xr-aaa-lib-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-aaa-lib-cfg/nc-update-xr-aaa-lib-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-create-xr-cdp-cfg-24-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-delete-xr-cdp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-delete-xr-cdp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-delete-xr-cdp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-delete-xr-cdp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-read-xr-cdp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-read-xr-cdp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-update-xr-cdp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-cdp-cfg/nc-update-xr-cdp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-20-ydk.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-21-ydk.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-30-ydk.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-31-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-31-ydk.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-32-ydk.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-33-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-33-ydk.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-34-ydk.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-35-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-35-ydk.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-40-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-41-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-41-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-52-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-52-ydk.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-53-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-53-ydk.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-54-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-55-ydk.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-56-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-56-ydk.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-57-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-57-ydk.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-58-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-58-ydk.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-59-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-59-ydk.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-create-xr-clns-isis-cfg-60-ydk.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-delete-xr-clns-isis-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-delete-xr-clns-isis-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-delete-xr-clns-isis-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-delete-xr-clns-isis-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-read-xr-clns-isis-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-read-xr-clns-isis-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-update-xr-clns-isis-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-cfg/nc-update-xr-clns-isis-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-20-ydk.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-clns-isis-oper/nc-read-xr-clns-isis-oper-22-ydk.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-create-xr-crypto-macsec-mka-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-create-xr-crypto-macsec-mka-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-delete-xr-crypto-macsec-mka-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-delete-xr-crypto-macsec-mka-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-read-xr-crypto-macsec-mka-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-read-xr-crypto-macsec-mka-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-update-xr-crypto-macsec-mka-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-crypto-macsec-mka-cfg/nc-update-xr-crypto-macsec-mka-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-create-xr-ethernet-lldp-cfg-24-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-delete-xr-ethernet-lldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-delete-xr-ethernet-lldp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-delete-xr-ethernet-lldp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-delete-xr-ethernet-lldp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-read-xr-ethernet-lldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-read-xr-ethernet-lldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-update-xr-ethernet-lldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ethernet-lldp-cfg/nc-update-xr-ethernet-lldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-22-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-24-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-30-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-32-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-34-ydk.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-36-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-create-xr-ifmgr-cfg-36-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-delete-xr-ifmgr-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-delete-xr-ifmgr-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-delete-xr-ifmgr-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-delete-xr-ifmgr-cfg-11-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-read-xr-ifmgr-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-read-xr-ifmgr-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-read-xr-ifmgr-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-read-xr-ifmgr-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-update-xr-ifmgr-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-update-xr-ifmgr-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-update-xr-ifmgr-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ifmgr-cfg/nc-update-xr-ifmgr-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-20-ydk.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-21-ydk.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-22-ydk.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-23-ydk.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-24-ydk.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-create-xr-infra-infra-cfg-25-ydk.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-delete-xr-infra-infra-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-read-xr-infra-infra-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-read-xr-infra-infra-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-update-xr-infra-infra-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-cfg/nc-update-xr-infra-infra-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-22-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-24-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-26-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-create-xr-infra-infra-clock-linux-cfg-28-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-read-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-read-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-update-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/nc-update-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-20-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-24-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-26-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-create-xr-infra-infra-locale-cfg-28-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-delete-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-delete-xr-infra-infra-locale-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-delete-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-delete-xr-infra-infra-locale-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-read-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-read-xr-infra-infra-locale-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-read-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-read-xr-infra-infra-locale-cfg-20-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-update-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-update-xr-infra-infra-locale-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-20-ydk.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-create-xr-infra-rsi-cfg-21-ydk.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-delete-xr-infra-rsi-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-delete-xr-infra-rsi-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-delete-xr-infra-rsi-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-delete-xr-infra-rsi-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-read-xr-infra-rsi-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-read-xr-infra-rsi-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-update-xr-infra-rsi-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-rsi-cfg/nc-update-xr-infra-rsi-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-22-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-24-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-26-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-28-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-30-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-32-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-40-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-42-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-50-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-50-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-51-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-51-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-52-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-52-ydk.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-53-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-53-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-60-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-60-ydk.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-62-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-create-xr-infra-syslog-cfg-62-ydk.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-11-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-delete-xr-infra-syslog-cfg-30-ydk.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-read-xr-infra-syslog-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/nc-update-xr-infra-syslog-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-20-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-21-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-22-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-23-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-24-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-25-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-30-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-31-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-32-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-33-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-34-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-35-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-create-xr-ip-domain-cfg-40-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-delete-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-delete-xr-ip-domain-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-delete-xr-ip-domain-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-delete-xr-ip-domain-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-read-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-read-xr-ip-domain-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-update-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/nc-update-xr-ip-domain-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-create-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-create-xr-ip-iep-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-delete-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-delete-xr-ip-iep-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-read-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-read-xr-ip-iep-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-update-xr-ip-iep-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-iep-cfg/nc-update-xr-ip-iep-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-20-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-21-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-22-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-23-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-24-ydk.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-create-xr-ip-ntp-cfg-25-ydk.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-delete-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-delete-xr-ip-ntp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-delete-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-delete-xr-ip-ntp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-read-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-read-xr-ip-ntp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-update-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/nc-update-xr-ip-ntp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-oper/nc-read-xr-ip-ntp-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-oper/nc-read-xr-ip-ntp-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-20-ydk.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-22-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-24-ydk.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-26-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-create-xr-ip-rsvp-cfg-28-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-delete-xr-ip-rsvp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-read-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-read-xr-ip-rsvp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-update-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/nc-update-xr-ip-rsvp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-20-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-21-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-22-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-23-ydk.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-24-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-create-xr-ip-static-cfg-25-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-30-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-31-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-31-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-delete-xr-ip-static-cfg-40-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-read-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-read-xr-ip-static-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-update-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/nc-update-xr-ip-static-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-22-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-30-ydk.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-32-ydk.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-34-ydk.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-80-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-80-ydk.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-82-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-82-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-84-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-84-ydk.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-86-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-create-xr-ipv4-acl-cfg-86-ydk.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-delete-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-delete-xr-ipv4-acl-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-delete-xr-ipv4-acl-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-delete-xr-ipv4-acl-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-read-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-read-xr-ipv4-acl-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-update-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/nc-update-xr-ipv4-acl-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-12-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-30-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-32-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-create-xr-ipv4-arp-cfg-34-ydk.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-11-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-12-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-delete-xr-ipv4-arp-cfg-30-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-read-xr-ipv4-arp-cfg-12-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/nc-update-xr-ipv4-arp-cfg-12-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-40-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-40-ydk.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-41-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-41-ydk.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-42-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-42-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-43-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-43-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-44-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-44-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-45-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-create-xr-ipv4-bgp-cfg-45-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-delete-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-delete-xr-ipv4-bgp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-delete-xr-ipv4-bgp-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-delete-xr-ipv4-bgp-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-read-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-read-xr-ipv4-bgp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-update-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/nc-update-xr-ipv4-bgp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-20-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-30-ydk.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-32-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-create-xr-ipv4-ospf-cfg-34-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-delete-xr-ipv4-ospf-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-delete-xr-ipv4-ospf-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-delete-xr-ipv4-ospf-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-delete-xr-ipv4-ospf-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-read-xr-ipv4-ospf-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-read-xr-ipv4-ospf-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-update-xr-ipv4-ospf-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-ospf-cfg/nc-update-xr-ipv4-ospf-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-create-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-delete-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-delete-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-delete-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-delete-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-read-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-read-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-update-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/nc-update-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-20-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-22-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-create-xr-lib-keychain-macsec-cfg-24-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-delete-xr-lib-keychain-macsec-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-delete-xr-lib-keychain-macsec-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-read-xr-lib-keychain-macsec-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-read-xr-lib-keychain-macsec-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-update-xr-lib-keychain-macsec-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-lib-keychain-macsec-cfg/nc-update-xr-lib-keychain-macsec-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-linux-os-reboot-history-oper/nc-read-xr-linux-os-reboot-history-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-linux-os-reboot-history-oper/nc-read-xr-linux-os-reboot-history-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-linux-os-reboot-history-oper/nc-read-xr-linux-os-reboot-history-oper-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-linux-os-reboot-history-oper/nc-read-xr-linux-os-reboot-history-oper-20-ydk.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-21-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-23-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-24-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-25-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-create-xr-man-ems-cfg-25-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-delete-xr-man-ems-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-delete-xr-man-ems-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-delete-xr-man-ems-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-delete-xr-man-ems-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-read-xr-man-ems-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-read-xr-man-ems-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-update-xr-man-ems-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-man-ems-cfg/nc-update-xr-man-ems-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-create-xr-mpls-ldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-create-xr-mpls-ldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-delete-xr-mpls-ldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-delete-xr-mpls-ldp-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-read-xr-mpls-ldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-read-xr-mpls-ldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-update-xr-mpls-ldp-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-cfg/nc-update-xr-mpls-ldp-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-oper/nc-read-xr-mpls-ldp-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-ldp-oper/nc-read-xr-mpls-ldp-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-create-xr-mpls-oam-cfg-24-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-delete-xr-mpls-oam-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-delete-xr-mpls-oam-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-delete-xr-mpls-oam-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-delete-xr-mpls-oam-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-read-xr-mpls-oam-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-read-xr-mpls-oam-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-update-xr-mpls-oam-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-oam-cfg/nc-update-xr-mpls-oam-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-20-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-22-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-24-ydk.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-26-ydk.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-create-xr-policy-repository-cfg-28-ydk.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-delete-xr-policy-repository-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-delete-xr-policy-repository-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-delete-xr-policy-repository-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-delete-xr-policy-repository-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-read-xr-policy-repository-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-read-xr-policy-repository-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-update-xr-policy-repository-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-policy-repository-cfg/nc-update-xr-policy-repository-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-20-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-21-ydk.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-22-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-create-xr-segment-routing-ms-cfg-23-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-delete-xr-segment-routing-ms-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-read-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-read-xr-segment-routing-ms-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-update-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/nc-update-xr-segment-routing-ms-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-create-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-create-xr-shellutil-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-create-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-create-xr-shellutil-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-delete-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-delete-xr-shellutil-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-delete-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-delete-xr-shellutil-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-read-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-read-xr-shellutil-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-read-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-read-xr-shellutil-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-update-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-update-xr-shellutil-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-update-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/nc-update-xr-shellutil-cfg-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-filesystem-oper/nc-read-xr-shellutil-filesystem-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-filesystem-oper/nc-read-xr-shellutil-filesystem-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-filesystem-oper/nc-read-xr-shellutil-filesystem-oper-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-filesystem-oper/nc-read-xr-shellutil-filesystem-oper-20-ydk.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-oper/nc-read-xr-shellutil-oper-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-oper/nc-read-xr-shellutil-oper-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-oper/nc-read-xr-shellutil-oper-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-oper/nc-read-xr-shellutil-oper-20-ydk.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-20-ydk.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-22-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-22-ydk.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-24-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-24-ydk.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-26-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-26-ydk.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-28-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-28-ydk.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-30-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-32-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-create-xr-telemetry-model-driven-cfg-34-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-delete-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-delete-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-delete-xr-telemetry-model-driven-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-delete-xr-telemetry-model-driven-cfg-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-read-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-read-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-update-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/nc-update-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-delete-oc-bgp-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-delete-oc-bgp-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-delete-oc-bgp-20-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-delete-oc-bgp-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-read-oc-bgp-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-read-oc-bgp-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-update-oc-bgp-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-update-oc-bgp-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-20-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-20-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-30-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-30-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-32-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-32-ydk.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-34-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-34-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-40-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-40-ydk.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-50-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-50-ydk.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-52-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-52-ydk.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-54-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-54-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-56-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-56-ydk.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-58-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-create-oc-mpls-58-ydk.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-delete-oc-mpls-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-delete-oc-mpls-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-delete-oc-mpls-20-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-delete-oc-mpls-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-read-oc-mpls-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-read-oc-mpls-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-mpls/nc-update-oc-mpls-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-mpls/nc-update-oc-mpls-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-22-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-22-ydk.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-24-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-24-ydk.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-26-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-26-ydk.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-28-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-create-oc-routing-policy-28-ydk.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-delete-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-delete-oc-routing-policy-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-delete-oc-routing-policy-20-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-delete-oc-routing-policy-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-read-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-read-oc-routing-policy-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-update-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-routing-policy/nc-update-oc-routing-policy-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-30-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-30-ydk.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-32-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-32-ydk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-34-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-create-oc-telemetry-34-ydk.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-delete-oc-telemetry-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-delete-oc-telemetry-10-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-delete-oc-telemetry-20-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-delete-oc-telemetry-20-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-read-oc-telemetry-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-read-oc-telemetry-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-update-oc-telemetry-10-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-telemetry/nc-update-oc-telemetry-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-11-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-11-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-12-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-12-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-13-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-13-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-30-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-30-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-32-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-32-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-34-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-34-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-40-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-40-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-42-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-42-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-44-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-44-ydk.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-50-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-50-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-52-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-52-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-54-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-54-ydk.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-20-ydk.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-22-ydk.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-24-ydk.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-26-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-26-ydk.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-28-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-28-ydk.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-112-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-112-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-113-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-113-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-114-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-114-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-115-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-115-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-116-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-116-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-125-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-125-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-126-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-126-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-127-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-127-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-128-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-128-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-129-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-129-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-130-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-130-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-131-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-131-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-132-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-132-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-133-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-133-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-134-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-134-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-135-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-135-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-136-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-136-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-137-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-137-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-138-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-138-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-139-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-139-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-140-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-140-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-141-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-141-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-200-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-200-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-201-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-201-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-210-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-210-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-211-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-211-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-212-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-212-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-213-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-213-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-214-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-214-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-215-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-215-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-216-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-216-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-217-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-217-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-300-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-300-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-302-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-302-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-304-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-304-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-306-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-306-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-308-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-308-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-310-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-310-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-312-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-312-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-314-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-314-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-316-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-316-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-318-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-318-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-400-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-400-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-402-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-402-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-404-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-404-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-406-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-406-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-408-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-408-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-410-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-410-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-412-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-412-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-414-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-414-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-416-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-416-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-418-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-418-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-420-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-420-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-422-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-422-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-424-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-424-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-426-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-426-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-440-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-440-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-442-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-442-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-444-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-444-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-446-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-446-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-448-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-448-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-450-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-450-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-500-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-500-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-502-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-502-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-504-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-504-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-506-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-506-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-510-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-510-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-512-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-512-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-514-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-514-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-520-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-520-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-522-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-522-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-530-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-530-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-532-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-532-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-540-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-540-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-542-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-542-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-550-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-550-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-552-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-552-ydk.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-900-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-900-ydk.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-20-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-22-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-24-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-10-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-10-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-20-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-20-ydk.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-22-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-22-ydk.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-24-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-24-ydk.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # log debug messages if verbose argument specified
     if args.verbose:
         logger = logging.getLogger("ydk")
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
         handler = logging.StreamHandler()
         formatter = logging.Formatter(("%(asctime)s - %(name)s - "
                                       "%(levelname)s - %(message)s"))


### PR DESCRIPTION
Starting in YDK-Py 0.6.0, logging level can be set to DEBUG or INFO. The
latter provides details similar to what DEBUG provided in earlier
versions of YDK-Py.