### PR TITLE
Add sample apps for XE interface configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-30-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XE-native.
+
+usage: nc-create-xe-native-interface-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    loopback.ip.address.primary.address = "172.16.255.1"
+    loopback.ip.address.primary.mask = "255.255.255.255"
+    native.interface.loopback.append(loopback)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, native)
+
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-30-ydk.xml
@@ -1,0 +1,17 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.255.1</address>
+            <mask>255.255.255.255</mask>
+          </primary>
+        </address>
+      </ip>
+    </Loopback>
+  </interface>
+</native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-32-ydk.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XE-native.
+
+usage: nc-create-xe-native-interface-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    prefix_list = loopback.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::ff:1/128"
+    loopback.ipv6.address.prefix_list.append(prefix_list)
+    native.interface.loopback.append(loopback)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, native)
+
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-32-ydk.xml
@@ -1,0 +1,16 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::ff:1/128</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+    </Loopback>
+  </interface>
+</native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XE-native.
+
+usage: nc-create-xe-native-interface-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # configure IPv4 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = 2
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    gigabitethernet.ip.address.primary.address = "172.16.1.0"
+    gigabitethernet.ip.address.primary.mask = "255.255.255.254"
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, native)
+
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.xml
@@ -1,0 +1,19 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.1.0</address>
+            <mask>255.255.255.254</mask>
+          </primary>
+        </address>
+      </ip>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XE-native.
+
+usage: nc-create-xe-native-interface-36-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # configure IPv6 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = 2
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    prefix_list = gigabitethernet.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::1:0/127"
+    gigabitethernet.ipv6.address.prefix_list.append(prefix_list)
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, native)
+
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.xml
@@ -1,0 +1,18 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::1:0/127</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>
+


### PR DESCRIPTION
Includes four custom apps to configure IPv4 and IPv6 interfaces on a
Cisco IOS XE device using the Cisco-IOS-XE-native model:
nc-create-xe-native-interface-30-ydk.py - IPv4 virtual interface (lo0)
nc-create-xe-native-interface-32-ydk.py - IPv6 virtual interface (lo0)
nc-create-xe-native-interface-34-ydk.py - IPv4 physical interface (ge2)
nc-create-xe-native-interface-36-ydk.py - IPv6 physical interface (ge2)