### PR TITLE
Add sample NETCONF apps to configure XE interfaces

### DIFF
--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-30-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-30-ydk.py
@@ -40,7 +40,12 @@ import logging
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    loopback.ip.address.primary.address = "172.16.255.1"
+    loopback.ip.address.primary.mask = "255.255.255.255"
+    native.interface.loopback.append(loopback) 
 
 
 if __name__ == "__main__":
@@ -77,7 +82,7 @@ if __name__ == "__main__":
 
     # edit configuration on NETCONF device
     # netconf.lock(provider, Datastore.running)
-    # netconf.edit_config(provider, Datastore.running, native)
+    netconf.edit_config(provider, Datastore.running, native)
     # netconf.unlock(provider, Datastore.running)
 
     exit()

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-30-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-30-ydk.xml
@@ -1,0 +1,16 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.255.1</address>
+            <mask>255.255.255.255</mask>
+          </primary>
+        </address>
+      </ip>
+    </Loopback>
+  </interface>
+</native>

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-32-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-32-ydk.py
@@ -40,7 +40,13 @@ import logging
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    prefix_list = loopback.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::ff:1/128"
+    loopback.ipv6.address.prefix_list.append(prefix_list)
+    native.interface.loopback.append(loopback) 
 
 
 if __name__ == "__main__":
@@ -77,7 +83,7 @@ if __name__ == "__main__":
 
     # edit configuration on NETCONF device
     # netconf.lock(provider, Datastore.running)
-    # netconf.edit_config(provider, Datastore.running, native)
+    netconf.edit_config(provider, Datastore.running, native)
     # netconf.unlock(provider, Datastore.running)
 
     exit()

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-32-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-32-ydk.xml
@@ -1,0 +1,15 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::ff:1/128</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+    </Loopback>
+  </interface>
+</native>

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.py
@@ -40,7 +40,15 @@ import logging
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # configure IPv4 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = 2
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    gigabitethernet.ip.address.primary.address = "172.16.1.0"
+    gigabitethernet.ip.address.primary.mask = "255.255.255.254"
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet) 
 
 
 if __name__ == "__main__":
@@ -77,7 +85,7 @@ if __name__ == "__main__":
 
     # edit configuration on NETCONF device
     # netconf.lock(provider, Datastore.running)
-    # netconf.edit_config(provider, Datastore.running, native)
+    netconf.edit_config(provider, Datastore.running, native)
     # netconf.unlock(provider, Datastore.running)
 
     exit()

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.xml
@@ -1,0 +1,18 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.1.0</address>
+            <mask>255.255.255.254</mask>
+          </primary>
+        </address>
+      </ip>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.py
@@ -40,7 +40,16 @@ import logging
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # configure IPv6 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = 2
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    prefix_list = gigabitethernet.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::1:0/127"
+    gigabitethernet.ipv6.address.prefix_list.append(prefix_list)
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet) 
 
 
 if __name__ == "__main__":
@@ -77,7 +86,7 @@ if __name__ == "__main__":
 
     # edit configuration on NETCONF device
     # netconf.lock(provider, Datastore.running)
-    # netconf.edit_config(provider, Datastore.running, native)
+    netconf.edit_config(provider, Datastore.running, native)
     # netconf.unlock(provider, Datastore.running)
 
     exit()

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.xml
@@ -1,0 +1,17 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::1:0/127</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>


### PR DESCRIPTION
Includes 4 custom apps to configure XE interfaces using the native XE model
and NETCONF service.
nc-edit-config-xe-native-interface-30-ydk.py - IPv4 virtual interface (lo0)
nc-edit-config-xe-native-interface-32-ydk.py - IPv6 virtual interface (lo0)
nc-edit-config-xe-native-interface-34-ydk.py - IPv4 physical interface (ge2)
nc-edit-config-xe-native-interface-36-ydk.py - IPv6 physical interface (ge2)