### PR TITLE
Add sample apps for encoding XE interface config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-30-ydk.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-interface-30-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    loopback.ip.address.primary.address = "172.16.255.1"
+    loopback.ip.address.primary.mask = "255.255.255.255"
+    native.interface.loopback.append(loopback)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-30-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-30-ydk.xml
@@ -1,0 +1,17 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.255.1</address>
+            <mask>255.255.255.255</mask>
+          </primary>
+        </address>
+      </ip>
+    </Loopback>
+  </interface>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-32-ydk.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-interface-32-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    loopback = native.interface.Loopback()
+    loopback.name = 0
+    loopback.description = "PRIMARY ROUTER LOOPBACK"
+    prefix_list = loopback.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::ff:1/128"
+    loopback.ipv6.address.prefix_list.append(prefix_list)
+    native.interface.loopback.append(loopback)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-32-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-32-ydk.xml
@@ -1,0 +1,16 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <Loopback>
+      <name>0</name>
+      <description>PRIMARY ROUTER LOOPBACK</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::ff:1/128</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+    </Loopback>
+  </interface>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-interface-34-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # configure IPv4 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = "2"
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    gigabitethernet.ip.address.primary.address = "172.16.1.0"
+    gigabitethernet.ip.address.primary.mask = "255.255.255.254"
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.xml
@@ -1,0 +1,19 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ip>
+        <address>
+          <primary>
+            <address>172.16.1.0</address>
+            <mask>255.255.255.254</mask>
+          </primary>
+        </address>
+      </ip>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-interface-36-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # configure IPv6 interface
+    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet.name = "2"
+    gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
+    gigabitethernet.mtu = 9192
+    prefix_list = gigabitethernet.ipv6.address.PrefixList()
+    prefix_list.prefix = "2001:db8::1:0/127"
+    gigabitethernet.ipv6.address.prefix_list.append(prefix_list)
+    gigabitethernet.load_interval = 30
+    native.interface.gigabitethernet.append(gigabitethernet)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.xml
@@ -1,0 +1,18 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <interface>
+    <GigabitEthernet>
+      <name>2</name>
+      <description>CONNECTS TO R1 (gigabitethernet3)</description>
+      <ipv6>
+        <address>
+          <prefix-list>
+            <prefix>2001:db8::1:0/127</prefix>
+          </prefix-list>
+        </address>
+      </ipv6>
+      <load-interval>30</load-interval>
+      <mtu>9192</mtu>
+    </GigabitEthernet>
+  </interface>
+</native>
+


### PR DESCRIPTION
Includes four custom apps to encode config for XE interfaces in XML:
cd-encode-xe-native-interface-30-ydk.py - IPv4 virtual interface (lo0)
cd-encode-xe-native-interface-32-ydk.py - IPv6 virtual interface (lo0)
cd-encode-xe-native-interface-34-ydk.py - IPv4 physical interface (ge2)
cd-encode-xe-native-interface-36-ydk.py - IPv6 physical interface (ge2)