### PR TITLE
Add sample apps for IOS XE OSPF configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.py
@@ -35,13 +35,26 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
     as xe_native
+from ydk.types import Empty
 import logging
 
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
 
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.255.255"
+    network.area = 0
+
+    ospf.network.append(network)
+    native.router.ospf.append(ospf)
 
 if __name__ == "__main__":
     """Execute main program."""

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.255.255</mask>
+        <area>0</area>
+      </network>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+    </ospf>
+  </router>
+</native>

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.py
@@ -35,13 +35,33 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
     as xe_native
+from ydk.types import Empty
 import logging
 
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
 
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+    native.router.ospf.append(ospf)
 
 if __name__ == "__main__":
     """Execute main program."""

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+    </ospf>
+  </router>
+</native>

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.py
@@ -35,13 +35,40 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
     as xe_native
+from ydk.types import Empty
 import logging
 
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
 
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+
+    # OSPF stub Area
+    area = ospf.Area()
+    area.id = 1
+    stub = area.Stub()
+    ospf.area.append(area)
+
+    native.router.ospf.append(ospf)
 
 if __name__ == "__main__":
     """Execute main program."""

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <area>
+        <id>1</id>
+      </area>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+    </ospf>
+  </router>
+</native>

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.py
@@ -18,7 +18,7 @@
 """
 Create configuration for model Cisco-IOS-XE-native.
 
-usage: nc-create-xe-native-router-ospf-34-ydk.py [-h] [-v] device
+usage: nc-create-xe-native-router-ospf-32-ydk.py [-h] [-v] device
 
 positional arguments:
   device         NETCONF device (ssh://user:password@host:port)
@@ -35,13 +35,42 @@ from ydk.services import CRUDService
 from ydk.providers import NetconfServiceProvider
 from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
     as xe_native
+from ydk.types import Empty
 import logging
 
 
 def config_native(native):
     """Add config data to native object."""
-    pass
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
 
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+
+    # OSPF stub Area
+    area = ospf.Area()
+    area.id = 1
+    stub = area.Stub()
+    stub.no_summary = Empty()
+    area.stub = stub
+    ospf.area.append(area)
+
+    native.router.ospf.append(ospf)
 
 if __name__ == "__main__":
     """Execute main program."""

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <area>
+        <id>1</id>
+        <stub>
+          <no-summary/>
+        </stub>
+      </area>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+    </ospf>
+  </router>
+</native>


### PR DESCRIPTION
Includes four custom apps to configure IOS XE OSPF using native YANG data model:

nc-create-xe-native-router-ospf-20-ydk.py - single area ipv4 router
nc-create-xe-native-router-ospf-30-ydk.py - ipv4 ABR
nc-create-xe-native-router-ospf-32-ydk.py - ipv4 ABR with stub area
nc-create-xe-native-router-ospf-34-ydk.py - ipv4 ABR with totally stub area