### PR TITLE
Add NETCONF sample apps for XR locale config

### DIFF
--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-copy-config-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-copy-config-xr-infra-infra-locale-cfg-10-ydk.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Copy configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-copy-config-xr-infra-infra-locale-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # copy configuration to NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    # netconf.copy_config(provider, Datastore.candidate, locale)
+    # netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-10-ydk.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    # netconf.edit_config(provider, Datastore.candidate, locale)
+    # netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountry.us
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguage.en
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, locale)
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.txt
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+locale country US
+locale language en
+end

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>us</country>
+  <language>en</language>
+</locale>
+

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountry.cn
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguage.zh
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, locale)
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.txt
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.txt
@@ -1,0 +1,3 @@
+locale country CN
+locale language zh
+end

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>cn</country>
+  <language>zh</language>
+</locale>
+

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountry.de
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguage.de
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, locale)
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.txt
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.txt
@@ -1,0 +1,3 @@
+locale country DE
+locale language de
+end

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>de</country>
+  <language>de</language>
+</locale>
+

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountry.br
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguage.pt
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, locale)
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.txt
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.txt
@@ -1,0 +1,3 @@
+locale country BR
+locale language pt
+end

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>br</country>
+  <language>pt</language>
+</locale>
+

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    # country and language configuration
+    locale.country = xr_infra_infra_locale_cfg.LocaleCountry.ng
+    locale.language = xr_infra_infra_locale_cfg.LocaleLanguage.en
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, locale)
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.txt
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.txt
@@ -1,0 +1,3 @@
+locale country NG
+locale language en
+end

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.xml
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.xml
@@ -1,0 +1,5 @@
+<locale xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg">
+  <country>ng</country>
+  <language>en</language>
+</locale>
+

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-get-config-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-get-config-xr-infra-infra-locale-cfg-10-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-get-config-xr-infra-infra-locale-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def process_locale(locale):
+    """Process config in locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+
+    # get configuration from NETCONF device
+    # locale = netconf.get_config(provider, Datastore.running)
+    process_locale(locale)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-get-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-get-xr-infra-infra-locale-cfg-10-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get all data for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-get-xr-infra-infra-locale-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def process_locale(locale):
+    """Process data in locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+
+    # get data from NETCONF device
+    # locale = netconf.get(provider, locale)
+    process_locale(locale)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-validate-xr-infra-infra-locale-cfg-10-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-locale-cfg/nc-validate-xr-infra-infra-locale-cfg-10-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Validate configuration for model Cisco-IOS-XR-infra-infra-locale-cfg.
+
+usage: nc-validate-xr-infra-infra-locale-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_locale_cfg \
+    as xr_infra_infra_locale_cfg
+import logging
+
+
+def config_locale(locale):
+    """Add config data to locale object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    locale = xr_infra_infra_locale_cfg.Locale()  # create object
+    config_locale(locale)  # add object configuration
+
+    # validate configuration on NETCONF device
+    # netconf.validate(provider, locale)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes five boilerplate apps and five custom apps to configure the
locale on an Cisco IOS XR device using the NETCONF service:
nc-copy-config-xr-infra-infra-locale-cfg-10-ydk.py - copy-config boilerp
nc-edit-config-xr-infra-infra-locale-cfg-10-ydk.py - edit-config boilerp
nc-edit-config-xr-infra-infra-locale-cfg-20-ydk.py - en_US
nc-edit-config-xr-infra-infra-locale-cfg-22-ydk.py - zh_CN
nc-edit-config-xr-infra-infra-locale-cfg-24-ydk.py - de_DE
nc-edit-config-xr-infra-infra-locale-cfg-26-ydk.py - pt_BR
nc-edit-config-xr-infra-infra-locale-cfg-28-ydk.py - en_NG
nc-get-config-xr-infra-infra-locale-cfg-10-ydk.py - get-config boilerpla
nc-get-xr-infra-infra-locale-cfg-10-ydk.py - get boilerplate
nc-validate-xr-infra-infra-locale-cfg-10-ydk.py - validate boilerplate