### PR TITLE
Add sample apps to configure OpenConfig terminal-device

### DIFF
--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.py
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for 2x100GE --> 2x100G model openconfig-terminal-device.
+
+usage: nc-edit-config-oc-terminal-device-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_terminal_device \
+    as oc_terminal_device
+from ydk.models.openconfig import openconfig_interfaces \
+    as oc_interfaces
+from ydk.models.openconfig import openconfig_platform \
+    as oc_platform
+from ydk.models.ietf import iana_if_type
+from ydk.models.openconfig import openconfig_transport_types \
+    as oc_tr_types
+from ydk.types import Decimal64
+import logging
+
+
+def config_interfaces(interfaces):
+    
+    """
+    Add config data for each line interface to be active
+    within the configured slice
+    """
+
+    ## port configuration of slice0
+    for LINE in ['Optics0/0/0/5', 'Optics0/0/0/6']:
+        interface = interfaces.Interface()
+        interface.name = LINE
+        if_config = interface.Config()
+        if_config.name = LINE
+        if_config.type = iana_if_type.OpticalchannelIdentity()
+        ## "True" means port is in "no shut" mode
+        ## "False" means port is in "shut" mode
+        if_config.enabled = True
+        interface.config = if_config
+        interfaces.interface.append(interface)
+
+
+def config_terminal_device(terminal_device):
+
+    """
+    Add config data for correlation between client
+    ports, logical channels and optical channels.
+    "2x100G client -> 2x100G line" slice mode.
+    In that mode in each slice first client port is
+    mapped to the first line port and last client port
+    is mapped to the second line port.
+    """
+    ## Define logical mapping between logical ethernet channels
+    ## and logical OTN channels
+
+    ## Creation of the logical number(index) for the client ports of slice0
+    NUM = 100
+    for CLIENT in ['0/0-Optics0/0/0/0', '0/0-Optics0/0/0/4']:
+        channel = terminal_device.logical_channels.Channel()
+        ## indexing can be any, except 0
+        channel.index = NUM
+        ## defining the Ethernet logical channel (speed, status, Eth mode)
+        channel_config = channel.Config()
+        channel_config.rate_class = oc_tr_types.Trib_Rate_100GIdentity()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.trib_protocol = oc_tr_types.Prot_100G_MlgIdentity()
+        channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+        channel.config = channel_config
+        ## mapping of the client physical port into the
+        ## assigned logical number (index)
+        channel_ingress = channel.Ingress()
+        channel_ingress_tr = channel_ingress.Config()
+        channel_ingress_tr.transceiver = CLIENT
+        channel_ingress.config = channel_ingress_tr
+        channel.ingress = channel_ingress
+        ## mapping the ethernet logical channel into the OTN logical channel
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        ## mapping the logical channel and the client port
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        ## Defining the allocation of client speed into the line port
+        channel_assignment_config.allocation = Decimal64('100')
+        channel_assignment_config.assignment_type = channel_assignment.\
+                                                    config.AssignmentTypeEnum.\
+                                                    LOGICAL_CHANNEL
+        ## defining the number of a line to be used for that client port
+        ## the line is also indexed and will be defined later
+        channel_assignment_config.logical_channel = NUM+100
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+    NUM = 200
+    for LINE in ['0/0-OpticalChannel0/0/0/5', '0/0-OpticalChannel0/0/0/6']:
+        ## Creation of the logical number (index) for the line ports of slice0
+        channel = terminal_device.logical_channels.Channel()
+        channel.index = NUM
+        ## OTN logical channel definition (OTN type, Enabled)
+        channel_config = channel.Config()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.logical_channel_type = oc_tr_types.Prot_OtnIdentity()
+        channel.config = channel_config
+        ## defining the speed of the line
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        channel_assignment_config.allocation = Decimal64('100')
+        channel_assignment_config.assignment_type = channel_assignment.config.\
+                                                    AssignmentTypeEnum.\
+                                                    OPTICAL_CHANNEL
+        ## and mapping into the optical channel
+        channel_assignment_config.optical_channel = LINE
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+
+def config_components(components):
+
+    """
+    Add config data for the optical channels (lines) and map to real ports
+    This is where you define output power and the wavelength
+    """
+
+    for LINE in [['0/0-OpticalChannel0/0/0/5', '0/0-Optics0/0/0/5', '0', 191300000],
+                  ['0/0-OpticalChannel0/0/0/6', '0/0-Optics0/0/0/6', '0', 196100000]]:
+        component = components.Component()
+        component.name = LINE[0]
+        optical_channel_config = component.optical_channel.Config()
+        ## mapping to a physical port on the box
+        optical_channel_config.line_port = LINE[1]
+        ## mode1 == FEC7%, mode 2 == FEC20%
+        optical_channel_config.operational_mode = 2
+        ## output power is expressed in increments of 0.01 dBm
+        optical_channel_config.target_output_power = Decimal64(LINE[2])
+        ## frequency of the optical channel, expressed in MHz
+        optical_channel_config.frequency = LINE[3]
+        component.optical_channel.config = optical_channel_config
+        components.component.append(component)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    # create OC-interfaces object (optical channels)
+    interfaces = oc_interfaces.Interfaces()
+    config_interfaces(interfaces)
+    
+    # create OC-Terminal_device object (mapping between logical ports)
+    terminal_device = oc_terminal_device.TerminalDevice()
+    config_terminal_device(terminal_device)
+    
+    # create OC-platform object (description for optical channels)
+    components = oc_platform.Components()
+    config_components(components)  
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, interfaces)
+    netconf.edit_config(provider, Datastore.candidate, terminal_device)
+    netconf.edit_config(provider, Datastore.candidate, components)    
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script
+
+
+##### helpfull commands to check the status on the NCS1002:
+
+### 'sh hw-module slice 0' to find the provisioning progress
+### 'sh terminal-device layout' to check accepted configuration \
+###    layout with a clear picture of logical channels and their mappings
+### 'sh terminal-device logical-channel <all|number>' to check details \
+###    either for all logical channels or for a specific one
+### 'sh terminal-device operational-modes' to check supported operational modes
+

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.txt
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.txt
@@ -1,0 +1,60 @@
+!
+controller Optics0/0/0/5
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1913000
+!
+controller Optics0/0/0/6
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1961000
+!
+terminal-device
+ logical-channel 100
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 101
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 200
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 100
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_5
+  !
+ !
+ logical-channel 201
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 100
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_6
+  !
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_5
+  line-port Optics0/0/0/5
+  operational-mode 2
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_6
+  line-port Optics0/0/0/6
+  operational-mode 2
+!

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.xml
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-20-ydk.xml
@@ -1,0 +1,130 @@
+<interfaces xmlns="http://openconfig.net/yang/interfaces">
+        <interface>
+          <name>Optics0/0/0/5</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/5</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+        <interface>
+          <name>Optics0/0/0/6</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/6</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+      </interfaces>
+
+      <terminal-device xmlns="http://openconfig.net/yang/terminal-device">
+        <logical-channels>
+          <channel>
+            <index>100</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>101</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>200</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/5</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>201</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/6</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+        </logical-channels>
+      </terminal-device>
+
+      <components xmlns="http://openconfig.net/yang/platform">
+        <component>
+          <name>0/0-OpticalChannel0/0/0/5</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>191300000</frequency>
+              <line-port>0/0-Optics0/0/0/5</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+        <component>
+          <name>0/0-OpticalChannel0/0/0/6</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>196100000</frequency>
+              <line-port>0/0-Optics0/0/0/6</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+      </components>

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.py
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for 4x100GE --> 2x200G model openconfig-terminal-device.
+
+usage: nc-edit-config-oc-terminal-device-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces \
+    as oc_interfaces
+from ydk.models.openconfig import openconfig_terminal_device \
+    as oc_terminal_device
+from ydk.models.openconfig import openconfig_platform \
+    as oc_platform
+from ydk.models.ietf import iana_if_type
+from ydk.models.openconfig import openconfig_transport_types \
+    as oc_tr_types
+from ydk.types import Decimal64
+import logging
+
+
+def config_interfaces(interfaces):
+    
+    """
+    Add config data for each line interface to be active
+    within the configured slice0
+    """
+    
+    ## port configuration 
+    for LINE in ['Optics0/0/0/5', 'Optics0/0/0/6']:
+        interface = interfaces.Interface()
+        interface.name = LINE
+        if_config = interface.Config()
+        if_config.name = LINE
+        if_config.type = iana_if_type.OpticalchannelIdentity()
+        ## "True" means port is in "no shut" mode
+        ## "False" means port is in "shut" mode
+        if_config.enabled = True
+        interface.config = if_config
+        interfaces.interface.append(interface)
+
+        
+def config_terminal_device(terminal_device):
+
+    """
+    Add config data for correlation between client
+    ports, logical channels and optical channels.
+    "4x100G client -> 2x200G line" slice mode.
+    In that mode in each slice first 2 client ports are
+    mapped to the first line port and last 2 client ports
+    are mapped to the second line port.
+    """
+    ## Define logical mapping between logical ethernet channels
+    ## and logical OTN channels
+
+    ## Creation of the logical number(index) for all the client ports of slice0
+    for j in [[0, '0/0-Optics0/0/0/0', 200], [10, '0/0-Optics0/0/0/1', 200],
+              [30, '0/0-Optics0/0/0/3', 201], [40, '0/0-Optics0/0/0/4', 201]]:
+        NUM = 100
+        channel = terminal_device.logical_channels.Channel()
+        ## indexing can be any, except 0.
+        channel.index = NUM + j[0]
+        ## defining the Ethernet logical channel (speed, status, Eth mode)
+        channel_config = channel.Config()
+        channel_config.rate_class = oc_tr_types.Trib_Rate_100GIdentity()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.trib_protocol = oc_tr_types.Prot_100G_MlgIdentity()
+        channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+        channel.config = channel_config
+        ## mapping of the client physical port into the
+        ## assigned logical number (index)
+        channel_ingress = channel.Ingress()
+        channel_ingress_tr = channel_ingress.Config()
+        channel_ingress_tr.transceiver = j[1]
+        channel_ingress.config = channel_ingress_tr
+        channel.ingress = channel_ingress
+        ## mapping the ethernet logical channel into the OTN logical channel
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        ## mapping the logical channel and the client port
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        ## Defining the allocation of client speed into the line port
+        channel_assignment_config.allocation = Decimal64('100')
+        channel_assignment_config.assignment_type = channel_assignment.\
+                                                    config.AssignmentTypeEnum.\
+                                                    LOGICAL_CHANNEL
+        ## defining the number of a line to be used for that client port
+        ## the line is also indexed and will be defined later
+        channel_assignment_config.logical_channel = j[2]
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+    NUM = 200
+    for LINE in ['0/0-OpticalChannel0/0/0/5', '0/0-OpticalChannel0/0/0/6']:
+        ## Creation of the logical number (index) for the line ports of slice0
+        channel = terminal_device.logical_channels.Channel()
+        channel.index = NUM
+        ## OTN logical channel definition (OTN type, Enabled)
+        channel_config = channel.Config()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.logical_channel_type = oc_tr_types.Prot_OtnIdentity()
+        channel.config = channel_config
+        ## defining the speed of the line
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        channel_assignment_config.allocation = Decimal64('200')
+        channel_assignment_config.assignment_type = channel_assignment.config.\
+                                                    AssignmentTypeEnum.\
+                                                    OPTICAL_CHANNEL
+        ## and mapping into the optical channel
+        channel_assignment_config.optical_channel = LINE
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+    
+def config_components(components):
+    
+    """
+    Add config data for the optical channels (lines) and map to real ports
+    This is where you define output power and the wavelength
+    """
+    
+    for LINE in [['0/0-OpticalChannel0/0/0/5', '0/0-Optics0/0/0/5', '0', 191300000],
+                  ['0/0-OpticalChannel0/0/0/6', '0/0-Optics0/0/0/6', '0', 196100000]]:
+        component = components.Component()
+        component.name = LINE[0]
+        optical_channel_config = component.optical_channel.Config()
+        ## mapping to a physical port on the box
+        optical_channel_config.line_port = LINE[1]
+        ## mode1 == FEC7%, mode 2 == FEC20%
+        optical_channel_config.operational_mode = 2
+        ## output power is expressed in increments of 0.01 dBm
+        optical_channel_config.target_output_power = Decimal64(LINE[2])
+        ## frequency of the optical channel, expressed in MHz
+        optical_channel_config.frequency = LINE[3] 
+        component.optical_channel.config = optical_channel_config
+        components.component.append(component)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    # create OC-interfaces object (optical channels)
+    interfaces = oc_interfaces.Interfaces()
+    config_interfaces(interfaces)
+    
+    # create OC-Terminal_device object (mapping between logical ports)
+    terminal_device = oc_terminal_device.TerminalDevice()
+    config_terminal_device(terminal_device)
+    
+    # create OC-platform object (description for optical channels)
+    components = oc_platform.Components()
+    config_components(components)  
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, interfaces)
+    netconf.edit_config(provider, Datastore.candidate, terminal_device)
+    netconf.edit_config(provider, Datastore.candidate, components)    
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script
+
+##### helpfull commands to check the status on the NCS1002:
+
+### 'sh hw-module slice 0' to find the provisioning progress
+### 'sh terminal-device layout' to check accepted configuration \
+###    layout with a clear picture of logical channels and their mappings
+### 'sh terminal-device logical-channel <all|number>' to check details \
+###    either for all logical channels or for a specific one
+### 'sh terminal-device operational-modes' to check supported operational modes

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.txt
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.txt
@@ -1,0 +1,86 @@
+!
+controller Optics0/0/0/5
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1913000
+!
+controller Optics0/0/0/6
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1961000
+!
+terminal-device
+ logical-channel 100
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 110
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 130
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 140
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 200
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 200
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_5
+  !
+ !
+ logical-channel 201
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 200
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_6
+  !
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_5
+  line-port Optics0/0/0/5
+  operational-mode 2
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_6
+  line-port Optics0/0/0/6
+  operational-mode 2
+ !
+!
+end

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.xml
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-22-ydk.xml
@@ -1,0 +1,180 @@
+      <interfaces xmlns="http://openconfig.net/yang/interfaces">
+        <interface>
+          <name>Optics0/0/0/5</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/5</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+        <interface>
+          <name>Optics0/0/0/6</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/6</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+      </interfaces>
+
+
+      <terminal-device xmlns="http://openconfig.net/yang/terminal-device">
+        <logical-channels>
+          <channel>
+            <index>100</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>110</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>130</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>140</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>200</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>200</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/5</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>201</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>200</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/6</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+        </logical-channels>
+      </terminal-device>
+
+
+      <components xmlns="http://openconfig.net/yang/platform">
+        <component>
+          <name>0/0-OpticalChannel0/0/0/5</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>191300000</frequency>
+              <line-port>0/0-Optics0/0/0/5</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+        <component>
+          <name>0/0-OpticalChannel0/0/0/6</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>196100000</frequency>
+              <line-port>0/0-Optics0/0/0/6</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+      </components>

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.py
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for 5x100GE --> 2x250G model openconfig-terminal-device.
+
+usage: nc-edit-config-oc-terminal-device-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces \
+    as oc_interfaces
+from ydk.models.openconfig import openconfig_terminal_device \
+    as oc_terminal_device
+from ydk.models.openconfig import openconfig_platform \
+    as oc_platform
+from ydk.models.ietf import iana_if_type
+from ydk.models.openconfig import openconfig_transport_types \
+    as oc_tr_types
+from ydk.types import Decimal64
+import logging
+
+
+def config_interfaces(interfaces):
+    
+    """
+    Add config data for each line interface to be active
+    within the configured slice0
+    """
+    
+    ## port configuration
+    for LINE in ['Optics0/0/0/5', 'Optics0/0/0/6']:
+        interface = interfaces.Interface()
+        interface.name = LINE
+        if_config = interface.Config()
+        if_config.name = LINE
+        if_config.type = iana_if_type.OpticalchannelIdentity()
+        ## "True" means port is in "no shut" mode
+        ## "False" means port is in "shut" mode
+        if_config.enabled = True
+        interface.config = if_config
+        interfaces.interface.append(interface)
+
+
+def config_terminal_device(terminal_device):
+
+    """
+    Add config data for correlation between client
+    ports, logical channels and optical channels.
+    "5x100G client -> 2x200G line" slice mode.
+    In that mode, in each slice, first 2 client ports are
+    mapped to the first line port and last 2 client ports
+    are mapped to the second line port. The port in the middle
+    is split across each line in 50/50 ratio
+    """
+    ## Define logical mapping between logical ethernet channels
+    ## and logical OTN channels 
+
+    ## Creation of the logical number(index) for the 1st, 2nd, 4th and
+    ## 5th client ports of slice0
+    for j in [[0, '0/0-Optics0/0/0/0', 200], [10, '0/0-Optics0/0/0/1', 200],
+              [30, '0/0-Optics0/0/0/3', 201], [40, '0/0-Optics0/0/0/4', 201]]:
+        NUM = 100
+        channel = terminal_device.logical_channels.Channel()
+        ## indexing can be any, except 0.
+        channel.index = NUM + j[0]
+        ## defining the Ethernet logical channel (speed, status, Eth mode)
+        channel_config = channel.Config()
+        channel_config.rate_class = oc_tr_types.Trib_Rate_100GIdentity()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.trib_protocol = oc_tr_types.Prot_100G_MlgIdentity()
+        channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+        channel.config = channel_config
+        ## mapping of the client physical port into the
+        ## assigned logical number (index)
+        channel_ingress = channel.Ingress()
+        channel_ingress_tr = channel_ingress.Config()
+        channel_ingress_tr.transceiver = j[1]
+        channel_ingress.config = channel_ingress_tr
+        channel.ingress = channel_ingress
+        ## mapping the ethernet logical channel into the OTN logical channel
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        ## mapping the logical channel and the client port
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        ## Defining the allocation of client speed into the line port
+        channel_assignment_config.allocation = Decimal64('100')
+        channel_assignment_config.assignment_type = channel_assignment.\
+                                                    config.AssignmentTypeEnum.\
+                                                    LOGICAL_CHANNEL
+        ## defining the number of a line to be used for that client port
+        ## the line is also indexed and will be defined later
+        channel_assignment_config.logical_channel = j[2]
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+    ## Creation of the logical number(index) for the third client port of slice0
+    channel = terminal_device.logical_channels.Channel()
+    ## indexing can be any, except 0. 
+    channel.index = 120
+    ## defining the Ethernet logical channel (speed, status, Eth mode)
+    channel_config = channel.Config()
+    channel_config.rate_class = oc_tr_types.Trib_Rate_100GIdentity()
+    channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+    channel_config.trib_protocol = oc_tr_types.Prot_100G_MlgIdentity()
+    channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+    channel.config = channel_config
+    ## mapping of the client physical port into the assigned logical number (index)
+    channel_ingress = channel.Ingress()
+    channel_ingress_tr = channel_ingress.Config()
+    channel_ingress_tr.transceiver = '0/0-Optics0/0/0/2'
+    channel_ingress.config = channel_ingress_tr
+    channel.ingress = channel_ingress
+    ## mapping the ethernet logical channel into the OTN logical channel
+    ## with this mode half of the channel goes to the line 200 and second half
+    ## goes to the line 201
+    for i in [0,1]:      
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        channel_assignment.index = 1+i
+        channel_assignment_config = channel_assignment.Config()
+        ## Defining the allocation of client speed into line port
+        channel_assignment_config.allocation = Decimal64('50')
+        channel_assignment_config.assignment_type = channel_assignment.\
+                                                    config.AssignmentTypeEnum.\
+                                                    LOGICAL_CHANNEL
+        ## defining the number of a line to be used for that client port
+        ## the line is also indexed and will be defined later
+        channel_assignment_config.logical_channel = 200 + i
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+
+    ## Creation of the logical number (index) for the line ports of slice0
+    NUM = 200
+    for LINE in ['0/0-OpticalChannel0/0/0/5', '0/0-OpticalChannel0/0/0/6']:
+        channel = terminal_device.logical_channels.Channel()
+        channel.index = NUM
+        ## OTN logical channel definition (OTN type, Enabled)
+        channel_config = channel.Config()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.logical_channel_type = oc_tr_types.Prot_OtnIdentity()
+        channel.config = channel_config
+        ## defining the speed of that port
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        channel_assignment_config.allocation = Decimal64('250')
+        channel_assignment_config.assignment_type = channel_assignment.config.\
+                                                    AssignmentTypeEnum.\
+                                                    OPTICAL_CHANNEL
+        ## and mapping into the optical channel
+        channel_assignment_config.optical_channel = LINE
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+
+def config_components(components):
+    
+    """
+    Add config data for optical channels (lines) and map to real ports
+    This is where you define output power and the wavelength
+    """
+    
+    for LINE in [['0/0-OpticalChannel0/0/0/5', '0/0-Optics0/0/0/5', '0', 191300000],
+                  ['0/0-OpticalChannel0/0/0/6', '0/0-Optics0/0/0/6', '0', 196100000]]:
+        component = components.Component()
+        component.name = LINE[0]
+        optical_channel_config = component.optical_channel.Config()
+        optical_channel_config.line_port = LINE[1]
+        ## mode1 == FEC7%, mode 2 == FEC20%
+        optical_channel_config.operational_mode = 2
+        ## output power is expressed in increments of 0.01 dBm
+        optical_channel_config.target_output_power = Decimal64(LINE[2])
+        ## frequency of the optical channel, expressed in MHz
+        optical_channel_config.frequency = LINE[3] 
+        component.optical_channel.config = optical_channel_config
+        components.component.append(component)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    # create OC-interfaces object (optical channels)
+    interfaces = oc_interfaces.Interfaces()
+    config_interfaces(interfaces)
+    
+    # create OC-Terminal_device object (mapping between logical ports)
+    terminal_device = oc_terminal_device.TerminalDevice()
+    config_terminal_device(terminal_device)
+    
+    # create OC-platform object (description for optical channels)
+    components = oc_platform.Components()
+    config_components(components)  
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, interfaces)
+    netconf.edit_config(provider, Datastore.candidate, terminal_device)
+    netconf.edit_config(provider, Datastore.candidate, components)    
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script
+
+##### helpfull commands to check the status on the NCS1002:
+
+### 'sh hw-module slice 0' to find the provisioning progress
+### 'sh terminal-device layout' to check accepted configuration \
+###    layout with a clear picture of logical channels and their mappings
+### 'sh terminal-device logical-channel <all|number>' to check details \
+###    either for all logical channels or for a specific one
+### 'sh terminal-device operational-modes' to check supported operational modes
+

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.txt
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.txt
@@ -1,0 +1,103 @@
+!
+controller Optics0/0/0/5
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1913000
+!
+controller Optics0/0/0/6
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1961000
+!
+terminal-device
+ logical-channel 100
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 110
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 120
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 50
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+  assignment-id 2
+   allocation 50
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 130
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 140
+  rate-class 100G
+  admin-state enable
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 100G-MLG
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 100
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 200
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 250
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_5
+  !
+ !
+ logical-channel 201
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 250
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_6
+  !
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_5
+  line-port Optics0/0/0/5
+  operational-mode 2
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_6
+  line-port Optics0/0/0/6
+  operational-mode 2
+ !
+!
+end

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.xml
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-24-ydk.xml
@@ -1,0 +1,244 @@
+      <interfaces xmlns="http://openconfig.net/yang/interfaces">
+        <interface>
+          <name>Optics0/0/0/5</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/5</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+        <interface>
+          <name>Optics0/0/0/6</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/6</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+      </interfaces>
+
+
+      <terminal-device xmlns="http://openconfig.net/yang/terminal-device">
+        <logical-channels>
+          <channel>
+            <index>100</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>110</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>130</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>140</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>120</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>50</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+              <assignment>
+                <index>2</index>
+                <config>
+                  <allocation>50</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>120</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_100G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_100G_MLG</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>50</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+              <assignment>
+                <index>2</index>
+                <config>
+                  <allocation>50</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>200</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>250</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/5</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>201</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>250</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/6</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+        </logical-channels>
+      </terminal-device>
+
+
+      <components xmlns="http://openconfig.net/yang/platform">
+        <component>
+          <name>0/0-OpticalChannel0/0/0/5</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>191300000</frequency>
+              <line-port>0/0-Optics0/0/0/5</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+        <component>
+          <name>0/0-OpticalChannel0/0/0/6</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>196100000</frequency>
+              <line-port>0/0-Optics0/0/0/6</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+      </components>

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.py
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for 20x10GE --> 1x200G model openconfig-terminal-device.
+
+usage: nc-edit-config-oc-terminal-device-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces \
+    as oc_interfaces
+from ydk.models.openconfig import openconfig_terminal_device \
+    as oc_terminal_device
+from ydk.models.openconfig import openconfig_platform \
+    as oc_platform
+from ydk.models.ietf import iana_if_type
+from ydk.models.openconfig import openconfig_transport_types \
+    as oc_tr_types
+from ydk.types import Decimal64
+import logging
+
+
+def config_interfaces(interfaces):
+    
+    """
+    Add config data for each line interface to be active
+    within the configured slice
+    """   
+
+    ## Trunk port configuration
+    interface = interfaces.Interface()
+    interface.name = 'Optics0/0/0/6'
+    if_config = interface.Config()
+    if_config.name = 'Optics0/0/0/6'
+    if_config.type = iana_if_type.OpticalchannelIdentity()
+    ## "True" means port is in "no shut" mode
+    ## "False" means port is in "shut" mode
+    if_config.enabled = True
+    interface.config = if_config
+    interfaces.interface.append(interface)
+
+
+def config_terminal_device(terminal_device):
+
+    """
+    Add config data for correlation between client
+    ports, logical channels and optical channels.
+    "20x10G client -> 1x200G line" slice mode.
+    In that mode in each client port is
+    mapped to the single (second) line port.
+    """
+    ## Define logical mapping between logical ethernet channels
+    ## and logical OTN channels
+
+    ## Creation of the logical number (index) for the client ports (4x10GE)
+    ## of slice0
+    for j in [[0, '0/0-Optics0/0/0/0'], [10, '0/0-Optics0/0/0/1'],
+          [20, '0/0-Optics0/0/0/2'], [30, '0/0-Optics0/0/0/3'],
+          [40, '0/0-Optics0/0/0/4']]:
+        NUM = 100
+        for i in range(1,5):       
+            channel = terminal_device.logical_channels.Channel()
+            ## indexing can be any, except 0. 
+            channel.index = NUM + j[0]
+            ## defining the Ethernet logical channel (speed, status, Eth mode)
+            channel_config = channel.Config()
+            channel_config.rate_class = oc_tr_types.Trib_Rate_10GIdentity()
+            channel_config.trib_protocol = oc_tr_types.Prot_10Ge_LanIdentity()
+            channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+            channel.config = channel_config
+            ## mapping of the client physical port into the 
+            ## assigned logical number (index)
+            channel_ingress = channel.Ingress()
+            channel_ingress_tr = channel_ingress.Config()
+            channel_ingress_tr.transceiver = j[1]
+            channel_ingress_tr.physical_channel.append(i)
+            channel_ingress.config = channel_ingress_tr
+            channel.ingress = channel_ingress
+            ## mapping the ethernet logical channel into the OTN logical channel
+            channel_assignment = channel.logical_channel_assignments.Assignment()
+            ## mapping the logical channel and the client port
+            channel_assignment.index = 1
+            channel_assignment_config = channel_assignment.Config()
+            ## Defining the allocation of client speed into the line port
+            channel_assignment_config.allocation = Decimal64('10')
+            channel_assignment_config.assignment_type = channel_assignment.\
+                                                        config.AssignmentTypeEnum.\
+                                                        LOGICAL_CHANNEL
+            ## defining the number of a line to be used for that client port
+            ## line is also indexed and will be defined later
+            channel_assignment_config.logical_channel = 200
+            channel_assignment.config = channel_assignment_config
+            channel.logical_channel_assignments.assignment.append(channel_assignment)
+            
+            terminal_device.logical_channels.channel.append(channel)
+            NUM = NUM + 1
+
+    ## Creation of the logical number(index) for the line port of slice0
+    channel = terminal_device.logical_channels.Channel()
+    channel.index = 200
+    ## OTN logical channel definition (OTN type, Enabled)
+    channel_config = channel.Config()
+    channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+    channel_config.logical_channel_type = oc_tr_types.Prot_OtnIdentity()
+    channel.config = channel_config
+    ## defining the speed of that port
+    channel_assignment = channel.logical_channel_assignments.Assignment()
+    channel_assignment.index = 1
+    channel_assignment_config = channel_assignment.Config()
+    channel_assignment_config.allocation = Decimal64('200')
+    channel_assignment_config.assignment_type = channel_assignment.config.\
+                                                AssignmentTypeEnum.\
+                                                OPTICAL_CHANNEL
+    ## and mapping into the optical channel
+    channel_assignment_config.optical_channel = '0/0-OpticalChannel0/0/0/6'
+    channel_assignment.config = channel_assignment_config
+    channel.logical_channel_assignments.assignment.append(channel_assignment)
+
+    terminal_device.logical_channels.channel.append(channel)
+
+    
+def config_components(components):
+    
+    """
+    Add config data for optical channels (lines) and map into real ports
+    This is where you define output power and the wavelength
+    """
+
+    component = components.Component()
+    component.name = '0/0-OpticalChannel0/0/0/6'
+    optical_channel_config = component.optical_channel.Config()
+    optical_channel_config.line_port = '0/0-Optics0/0/0/6'
+    ## mode1 == FEC7%, mode 2 == FEC20%
+    optical_channel_config.operational_mode = 2
+    ## output power is expressed in increments of 0.01 dBm
+    optical_channel_config.target_output_power = Decimal64('0')
+    ## frequency of the optical channel, expressed in MHz
+    optical_channel_config.frequency = 191300000
+    component.optical_channel.config = optical_channel_config
+    components.component.append(component) 
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    # create OC-interfaces object (optical channels)
+    interfaces = oc_interfaces.Interfaces()
+    config_interfaces(interfaces)
+    
+    # create OC-Terminal_device object (mapping between logical ports)
+    terminal_device = oc_terminal_device.TerminalDevice()
+    config_terminal_device(terminal_device)
+    
+    # create OC-platform object (description for optical channels)
+    components = oc_platform.Components()
+    config_components(components)  
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, interfaces)
+    netconf.edit_config(provider, Datastore.candidate, terminal_device)
+    netconf.edit_config(provider, Datastore.candidate, components)    
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script
+
+##### helpfull commands to check the status on the NCS1002:
+
+### 'sh hw-module slice 0' to find the provisioning progress
+### 'sh terminal-device layout' to check accepted configuration \
+###    layout with a clear picture of logical channels and their mappings
+### 'sh terminal-device logical-channel <all|number>' to check details \
+###    either for all logical channels or for a specific one
+### 'sh terminal-device operational-modes' to check supported operational modes

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.txt
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.txt
@@ -1,0 +1,261 @@
+!
+controller Optics0/0/0/6
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1961000
+!
+terminal-device
+ logical-channel 100
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 101
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 102
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 103
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 110
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 111
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 112
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 113
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !        
+ logical-channel 120
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 121
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 122
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 123
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 130
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 131
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 132
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 133
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 140
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 141
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 142
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 143
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 200
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 200
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_6
+  !
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_6
+  line-port Optics0/0/0/6
+  operational-mode 2
+ !
+!
+end

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.xml
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-30-ydk.xml
@@ -1,0 +1,528 @@
+      <interfaces xmlns="http://openconfig.net/yang/interfaces">
+        <interface>
+          <name>Optics0/0/0/6</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/6</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+      </interfaces>
+
+
+      <terminal-device xmlns="http://openconfig.net/yang/terminal-device">
+        <logical-channels>
+          <channel>
+            <index>100</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>101</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>102</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>103</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>110</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>111</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>112</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>113</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>120</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>121</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>122</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>123</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>130</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>131</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>132</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>133</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>140</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>141</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>142</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>143</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>200</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>200</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/6</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+        </logical-channels>
+      </terminal-device>
+
+
+      <components xmlns="http://openconfig.net/yang/platform">
+        <component>
+          <name>0/0-OpticalChannel0/0/0/6</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>191300000</frequency>
+              <line-port>0/0-Optics0/0/0/6</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+      </components>

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.py
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Edit configuration for 20x10GE --> 2x100G model openconfig-terminal-device.
+
+usage: nc-edit-config-oc-terminal-device-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import NetconfService, Datastore
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces \
+    as oc_interfaces
+from ydk.models.openconfig import openconfig_terminal_device \
+    as oc_terminal_device
+from ydk.models.openconfig import openconfig_platform \
+    as oc_platform
+from ydk.models.ietf import iana_if_type
+from ydk.models.openconfig import openconfig_transport_types \
+    as oc_tr_types
+from ydk.types import Decimal64
+import logging
+
+def config_interfaces(interfaces):
+    
+    """
+    Add config data for each line interface to be active
+    within the configured slice0
+    """
+
+    ## port configuration
+    for LINE in ['Optics0/0/0/5', 'Optics0/0/0/6']:
+        interface = interfaces.Interface()
+        interface.name = LINE
+        if_config = interface.Config()
+        if_config.name = LINE
+        if_config.type = iana_if_type.OpticalchannelIdentity()
+        ## "True" means port is in "no shut" mode
+        ## "False" means port is in "shut" mode
+        if_config.enabled = True
+        interface.config = if_config
+        interfaces.interface.append(interface)
+
+def config_terminal_device(terminal_device):
+
+    """
+    Add config data for correlation between client
+    ports, logical channels and optical channels.
+    "20x10G client -> 2x100G line" slice mode.
+    In that mode each 10 client ports are 
+    mapped to the each line port.
+    """
+    
+    ## Define logical mapping between logical ethernet channels
+    ## and logical OTN channels
+
+    ## Creation of the logical number (index) for the 1st,2nd,3d,4th
+    ## client ports (4x10GE) of slice0
+    for j in [[0, '0/0-Optics0/0/0/0', 200], [10, '0/0-Optics0/0/0/1', 200],
+              [30, '0/0-Optics0/0/0/3', 201], [40, '0/0-Optics0/0/0/4', 201]]:
+        NUM = 100
+        for i in range(1,5):       
+            channel = terminal_device.logical_channels.Channel()
+            ## indexing can be any, except 0. 
+            channel.index = NUM + j[0] 
+            ## defining the Ethernet logical channel (speed, status, Eth mode)
+            channel_config = channel.Config()
+            channel_config.rate_class = oc_tr_types.Trib_Rate_10GIdentity()
+            channel_config.trib_protocol = oc_tr_types.Prot_10Ge_LanIdentity()
+            channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+            channel.config = channel_config
+            ## mapping of the client physical port into the
+            ## assigned logical number (index)
+            channel_ingress = channel.Ingress()
+            channel_ingress_tr = channel_ingress.Config()
+            channel_ingress_tr.transceiver = j[1]
+            channel_ingress_tr.physical_channel.append(i)
+            channel_ingress.config = channel_ingress_tr
+            channel.ingress = channel_ingress
+            ## mapping the ethernet logical channel into the OTN logical channel
+            channel_assignment = channel.logical_channel_assignments.Assignment()
+            ## mapping the logical channel and the client port
+            channel_assignment.index = 1
+            channel_assignment_config = channel_assignment.Config()
+            ## Defining the allocation of client speed into the line port
+            channel_assignment_config.allocation = Decimal64('10')
+            channel_assignment_config.assignment_type = channel_assignment.\
+                                                        config.AssignmentTypeEnum.\
+                                                        LOGICAL_CHANNEL
+            ## defining the number of a line to be used for that client port
+            ## the line is also indexed and will be defined later
+            channel_assignment_config.logical_channel = j[2]
+            channel_assignment.config = channel_assignment_config
+            channel.logical_channel_assignments.assignment.append(channel_assignment)
+            terminal_device.logical_channels.channel.append(channel)
+            NUM = NUM + 1
+
+    ## Creation of the logical number(index) for
+    ## the 3d client port (first 2x10GE) of slice0
+    for j in [[20, 1, 201], [21, 2, 201],
+              [22, 3, 200], [23, 4, 200]]:
+        NUM = 100
+        channel = terminal_device.logical_channels.Channel()
+        ## indexing can be any, except 0. 
+        channel.index = NUM + j[0]
+        ## defining the Ethernet logical channel (speed, status, Eth mode)
+        channel_config = channel.Config()
+        channel_config.rate_class = oc_tr_types.Trib_Rate_10GIdentity()
+        channel_config.trib_protocol = oc_tr_types.Prot_10Ge_LanIdentity()
+        channel_config.logical_channel_type = oc_tr_types.Prot_EthernetIdentity()
+        channel.config = channel_config
+        ## mapping of the client physical port into the
+        ## assigned logical number (index)
+        channel_ingress = channel.Ingress()
+        channel_ingress_tr = channel_ingress.Config()
+        channel_ingress_tr.transceiver = '0/0-Optics0/0/0/2'
+        channel_ingress_tr.physical_channel.append(j[1])
+        channel_ingress.config = channel_ingress_tr
+        channel.ingress = channel_ingress
+        ## mapping the ethernet logical channel into the OTN logical channel
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        ## mapping the logical channel and the client port
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        ## Defining tbe allocation of client speed into the line port
+        channel_assignment_config.allocation = Decimal64('10')
+        channel_assignment_config.assignment_type = channel_assignment.\
+                                                    config.AssignmentTypeEnum.\
+                                                    LOGICAL_CHANNEL
+        ## defining the number of a line to be used for that client port
+        ## the line is also indexed and will be defined later
+        channel_assignment_config.logical_channel = j[2]
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)  
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+
+    ## Creation of the logical number(index) for the line ports of slice0
+    NUM = 200
+    for LINE in ['0/0-OpticalChannel0/0/0/5', '0/0-OpticalChannel0/0/0/6']:
+        channel = terminal_device.logical_channels.Channel()
+        channel.index = NUM
+        ## OTN logical channel definition (OTN type, Enabled)
+        channel_config = channel.Config()
+        channel_config.admin_state = oc_tr_types.AdminStateTypeEnum.ENABLED
+        channel_config.logical_channel_type = oc_tr_types.Prot_OtnIdentity()
+        channel.config = channel_config
+        ## defining the speed of that port
+        channel_assignment = channel.logical_channel_assignments.Assignment()
+        channel_assignment.index = 1
+        channel_assignment_config = channel_assignment.Config()
+        channel_assignment_config.allocation = Decimal64('100')
+        channel_assignment_config.assignment_type = channel_assignment.config.\
+                                                    AssignmentTypeEnum.\
+                                                    OPTICAL_CHANNEL
+        ## and mapping into the optical channel
+        channel_assignment_config.optical_channel = LINE
+        channel_assignment.config = channel_assignment_config
+        channel.logical_channel_assignments.assignment.append(channel_assignment)
+        terminal_device.logical_channels.channel.append(channel)
+        NUM = NUM + 1
+    
+def config_components(components):
+    
+    """
+    Add config data for optical channels (lines)
+    This is where you define output power and the wavelength
+    """
+
+    for LINE in [['0/0-OpticalChannel0/0/0/5', '0/0-Optics0/0/0/5', '0', 191300000],
+                  ['0/0-OpticalChannel0/0/0/6', '0/0-Optics0/0/0/6', '0', 196100000]]:
+
+        component = components.Component()
+        component.name = LINE[0]
+        optical_channel_config = component.optical_channel.Config()
+        optical_channel_config.line_port = LINE[1]
+        ## mode1 == FEC7%, mode 2 == FEC20%
+        optical_channel_config.operational_mode = 2
+        ## output power is expressed in increments of 0.01 dBm
+        optical_channel_config.target_output_power = Decimal64(LINE[2])
+        ## frequency of the optical channel, expressed in MHz
+        optical_channel_config.frequency = LINE[3] 
+        component.optical_channel.config = optical_channel_config
+        components.component.append(component)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create NETCONF service
+    netconf = NetconfService()
+
+    # create OC-interfaces object (optical channels)
+    interfaces = oc_interfaces.Interfaces()
+    config_interfaces(interfaces)
+    
+    # create OC-Terminal_device object (mapping between logical ports)
+    terminal_device = oc_terminal_device.TerminalDevice()
+    config_terminal_device(terminal_device)
+    
+    # create OC-platform object (description for optical channels)
+    components = oc_platform.Components()
+    config_components(components)  
+
+    # edit configuration on NETCONF device
+    # netconf.lock(provider, Datastore.candidate)
+    netconf.edit_config(provider, Datastore.candidate, interfaces)
+    netconf.edit_config(provider, Datastore.candidate, terminal_device)
+    netconf.edit_config(provider, Datastore.candidate, components)    
+    netconf.commit(provider)
+    # netconf.unlock(provider, Datastore.candidate)
+
+    exit()
+# End of script
+
+##### helpfull commands to check the status on the NCS1002:
+
+### 'sh hw-module slice 0' to find the provisioning progress
+### 'sh terminal-device layout' to check accepted configuration \
+###    layout with a clear picture of logical channels and their mappings
+### 'sh terminal-device logical-channel <all|number>' to check details \
+###    either for all logical channels or for a specific one
+### 'sh terminal-device operational-modes' to check supported operational modes

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.txt
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.txt
@@ -1,0 +1,278 @@
+!
+controller Optics0/0/0/5
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1913000
+!
+controller Optics0/0/0/6
+ transmit-power 0
+ dwdm-carrier 100MHz-grid frequency 1961000
+!
+terminal-device
+ logical-channel 100
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 101
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 102
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 103
+  rate-class 10G
+  ingress-client-port Optics0/0/0/0
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 110
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 111
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 112
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 113
+  rate-class 10G
+  ingress-client-port Optics0/0/0/1
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !       
+ !
+ logical-channel 120
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 121
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 122
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 123
+  rate-class 10G
+  ingress-client-port Optics0/0/0/2
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 200
+  !
+ !
+ logical-channel 130
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 131
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 132
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 133
+  rate-class 10G
+  ingress-client-port Optics0/0/0/3
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 140
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 1
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 141
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 2
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 142
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 3
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 143
+  rate-class 10G
+  ingress-client-port Optics0/0/0/4
+  trib-protocol 10GE-LAN
+  ingress-physical-channel 4
+  logical-channel-type Ethernet
+  assignment-id 1
+   allocation 10
+   assignment-type logical
+   assigned-logical-channel 201
+  !
+ !
+ logical-channel 200
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 100
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_5
+  !
+ !
+ logical-channel 201
+  admin-state enable
+  logical-channel-type Otn
+  assignment-id 1
+   allocation 100
+   assignment-type optical
+   assigned-optical-channel 0_0-OpticalChannel0_0_0_6
+  !
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_5
+  line-port Optics0/0/0/5
+  operational-mode 2
+ !
+ optical-channel 0_0-OpticalChannel0_0_0_6
+  line-port Optics0/0/0/6
+  operational-mode 2
+ !        
+!
+end

--- a/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.xml
+++ b/samples/basic/netconf/models/openconfig/openconfig-terminal-device/nc-edit-config-oc-terminal-device-32-ydk.xml
@@ -1,0 +1,564 @@
+      <interfaces xmlns="http://openconfig.net/yang/interfaces">
+        <interface>
+          <name>Optics0/0/0/5</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/5</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+        <interface>
+          <name>Optics0/0/0/6</name>
+          <config>
+            <enabled>true</enabled>
+            <name>Optics0/0/0/6</name>
+            <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:opticalChannel</type>
+          </config>
+        </interface>
+      </interfaces>
+
+
+      <terminal-device xmlns="http://openconfig.net/yang/terminal-device">
+        <logical-channels>
+          <channel>
+            <index>100</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>101</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>102</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>103</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/0</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>110</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>111</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>112</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>113</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/1</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>130</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>131</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>132</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>133</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/3</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>140</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>141</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>142</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>143</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/4</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>120</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>1</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>121</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>2</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>201</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>122</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>3</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>123</index>
+            <config>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_ETHERNET</logical-channel-type>
+              <rate-class xmlns:idx="http://openconfig.net/yang/transport-types">idx:TRIB_RATE_10G</rate-class>
+              <trib-protocol xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_10GE_LAN</trib-protocol>
+            </config>
+            <ingress>
+              <config>
+                <physical-channel>4</physical-channel>
+                <transceiver>0/0-Optics0/0/0/2</transceiver>
+              </config>
+            </ingress>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>10</allocation>
+                  <assignment-type>LOGICAL_CHANNEL</assignment-type>
+                  <logical-channel>200</logical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>200</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/5</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+          <channel>
+            <index>201</index>
+            <config>
+              <admin-state>ENABLED</admin-state>
+              <logical-channel-type xmlns:idx="http://openconfig.net/yang/transport-types">idx:PROT_OTN</logical-channel-type>
+            </config>
+            <logical-channel-assignments>
+              <assignment>
+                <index>1</index>
+                <config>
+                  <allocation>100</allocation>
+                  <assignment-type>OPTICAL_CHANNEL</assignment-type>
+                  <optical-channel>0/0-OpticalChannel0/0/0/6</optical-channel>
+                </config>
+              </assignment>
+            </logical-channel-assignments>
+          </channel>
+        </logical-channels>
+      </terminal-device>
+
+
+      <components xmlns="http://openconfig.net/yang/platform">
+        <component>
+          <name>0/0-OpticalChannel0/0/0/5</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>191300000</frequency>
+              <line-port>0/0-Optics0/0/0/5</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+        <component>
+          <name>0/0-OpticalChannel0/0/0/6</name>
+          <optical-channel xmlns="http://openconfig.net/yang/terminal-device">
+            <config>
+              <frequency>196100000</frequency>
+              <line-port>0/0-Optics0/0/0/6</line-port>
+              <operational-mode>2</operational-mode>
+              <target-output-power>0</target-output-power>
+            </config>
+          </optical-channel>
+        </component>
+      </components>


### PR DESCRIPTION
Includes five custom apps to configure an optical transponder
using the openconfig-terminal-device data model. Apps also use
the openconfig-interfaces and openconfig-platform models to
produce a complete configuration for Cisco NCS1002 platform.

nc-edit-config-oc-terminal-device-20-ydk.py - 2x100GE->2x100G
nc-edit-config-oc-terminal-device-22-ydk.py - 4x100GE->2x200G
nc-edit-config-oc-terminal-device-24-ydk.py - 5x100GE->2x250G
nc-edit-config-oc-terminal-device-30-ydk.py - 20x10GE->1x200G
nc-edit-config-oc-terminal-device-32-ydk.py - 20x10GE->2x100G