### PR TITLE
Update executor sample apps

### DIFF
--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-10-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
-    """Add RPC input data to roll_back_configuration_last_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
-    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationLast()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+    # executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-11-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-11-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc):
-    """Add RPC input data to roll_back_configuration_to_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToRpc()  # create object
-    prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationTo()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, roll_back_configuration_to_rpc)
+    # executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-12-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-12-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc):
-    """Add RPC input data to roll_back_configuration_to_exclude_rpc object."""
+def prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude):
+    """Add RPC input data to roll_back_configuration_to_exclude object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_exclude_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToExcludeRpc()  # create object
-    prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc)  # add RPC input
+    roll_back_configuration_to_exclude = xr_cfgmgr_rollback_act.RollBackConfigurationToExclude()  # create object
+    prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, roll_back_configuration_to_exclude_rpc)
+    # executor.execute_rpc(provider, roll_back_configuration_to_exclude)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-13-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-13-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_rpc(roll_back_configuration_rpc):
-    """Add RPC input data to roll_back_configuration_rpc object."""
+def prepare_roll_back_configuration(roll_back_configuration):
+    """Add RPC input data to roll_back_configuration object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationRpc()  # create object
-    prepare_roll_back_configuration_rpc(roll_back_configuration_rpc)  # add RPC input
+    roll_back_configuration = xr_cfgmgr_rollback_act.RollBackConfiguration()  # create object
+    prepare_roll_back_configuration(roll_back_configuration)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, roll_back_configuration_rpc)
+    # executor.execute_rpc(provider, roll_back_configuration)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-20-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
-    """Add RPC input data to roll_back_configuration_last_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # roll back most recent change
-    roll_back_configuration_last_rpc.input.count = 1
+    roll_back_configuration_to.input.count = 1
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
-    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationLast()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-22-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
-    """Add RPC input data to roll_back_configuration_last_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # roll back the two most recent changes
-    roll_back_configuration_last_rpc.input.comment = "Simple programmatic rollback"
-    roll_back_configuration_last_rpc.input.count = 2
+    roll_back_configuration_to.input.comment = "Simple programmatic rollback"
+    roll_back_configuration_to.input.count = 2
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
-    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationLast()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-24-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc):
-    """Add RPC input data to roll_back_configuration_last_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # force roll back for the five most recent changes
-    roll_back_configuration_last_rpc.input.comment = "Forced programmatic rollback"
-    roll_back_configuration_last_rpc.input.count = 5
-    roll_back_configuration_last_rpc.input.force = True
-    roll_back_configuration_last_rpc.input.label = "PRB-005"
+    roll_back_configuration_to.input.comment = "Forced programmatic rollback"
+    roll_back_configuration_to.input.count = 5
+    roll_back_configuration_to.input.force = True
+    roll_back_configuration_to.input.label = "PRB-005"
 
 
 if __name__ == "__main__":
@@ -76,11 +76,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_last_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationLastRpc()  # create object
-    prepare_roll_back_configuration_last_rpc(roll_back_configuration_last_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationLast()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_last_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-30-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-30-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc):
-    """Add RPC input data to roll_back_configuration_to_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # roll back to specific commit id
-    roll_back_configuration_to_rpc.input.commit_id = "1000000010"
+    roll_back_configuration_to.input.commit_id = "1000000010"
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToRpc()  # create object
-    prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationTo()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-32-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-32-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc):
-    """Add RPC input data to roll_back_configuration_to_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # roll back to specific commit id
-    roll_back_configuration_to_rpc.input.comment = "Simple programmatic rollback"
-    roll_back_configuration_to_rpc.input.commit_id = "1000000010"
+    roll_back_configuration_to.input.comment = "Simple programmatic rollback"
+    roll_back_configuration_to.input.commit_id = "1000000010"
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToRpc()  # create object
-    prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationTo()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-34-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-34-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc):
-    """Add RPC input data to roll_back_configuration_to_rpc object."""
+def prepare_roll_back_configuration_to(roll_back_configuration_to):
+    """Add RPC input data to roll_back_configuration_to object."""
     # roll back to specific commit id
-    roll_back_configuration_to_rpc.input.comment = "Forced programmatic rollback"
-    roll_back_configuration_to_rpc.input.commit_id = "1000000010"
-    roll_back_configuration_to_rpc.input.force = True
-    roll_back_configuration_to_rpc.input.label = "PRB-005"
+    roll_back_configuration_to.input.comment = "Forced programmatic rollback"
+    roll_back_configuration_to.input.commit_id = "1000000010"
+    roll_back_configuration_to.input.force = True
+    roll_back_configuration_to.input.label = "PRB-005"
 
 
 if __name__ == "__main__":
@@ -76,11 +76,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToRpc()  # create object
-    prepare_roll_back_configuration_to_rpc(roll_back_configuration_to_rpc)  # add RPC input
+    roll_back_configuration_to = xr_cfgmgr_rollback_act.RollBackConfigurationTo()  # create object
+    prepare_roll_back_configuration_to(roll_back_configuration_to)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-40-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-40-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc):
-    """Add RPC input data to roll_back_configuration_to_exclude_rpc object."""
+def prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude):
+    """Add RPC input data to roll_back_configuration_to_exclude object."""
     # roll back to (but excluding) specific commit id
-    roll_back_configuration_to_exclude_rpc.input.commit_id = "1000000010"
+    roll_back_configuration_to_exclude.input.commit_id = "1000000010"
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_exclude_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToExcludeRpc()  # create object
-    prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc)  # add RPC input
+    roll_back_configuration_to_exclude = xr_cfgmgr_rollback_act.RollBackConfigurationToExclude()  # create object
+    prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_exclude_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to_exclude)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-42-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-42-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc):
-    """Add RPC input data to roll_back_configuration_to_exclude_rpc object."""
+def prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude):
+    """Add RPC input data to roll_back_configuration_to_exclude object."""
     # roll back to (but excluding) specific commit id
-    roll_back_configuration_to_exclude_rpc.input.comment = "Simple programmatic rollback"
-    roll_back_configuration_to_exclude_rpc.input.commit_id = "1000000010"
+    roll_back_configuration_to_exclude.input.comment = "Simple programmatic rollback"
+    roll_back_configuration_to_exclude.input.commit_id = "1000000010"
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_exclude_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToExcludeRpc()  # create object
-    prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc)  # add RPC input
+    roll_back_configuration_to_exclude = xr_cfgmgr_rollback_act.RollBackConfigurationToExclude()  # create object
+    prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_exclude_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to_exclude)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-44-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-44-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc):
-    """Add RPC input data to roll_back_configuration_to_exclude_rpc object."""
+def prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude):
+    """Add RPC input data to roll_back_configuration_to_exclude object."""
     # roll back to (but excluding) specific commit id
-    roll_back_configuration_to_exclude_rpc.input.comment = "Forced programmatic rollback"
-    roll_back_configuration_to_exclude_rpc.input.commit_id = "1000000010"
-    roll_back_configuration_to_exclude_rpc.input.force = True
-    roll_back_configuration_to_exclude_rpc.input.label = "PRB-005"
+    roll_back_configuration_to_exclude.input.comment = "Forced programmatic rollback"
+    roll_back_configuration_to_exclude.input.commit_id = "1000000010"
+    roll_back_configuration_to_exclude.input.force = True
+    roll_back_configuration_to_exclude.input.label = "PRB-005"
 
 
 
@@ -77,11 +77,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_to_exclude_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationToExcludeRpc()  # create object
-    prepare_roll_back_configuration_to_exclude_rpc(roll_back_configuration_to_exclude_rpc)  # add RPC input
+    roll_back_configuration_to_exclude = xr_cfgmgr_rollback_act.RollBackConfigurationToExclude()  # create object
+    prepare_roll_back_configuration_to_exclude(roll_back_configuration_to_exclude)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_to_exclude_rpc)
+    executor.execute_rpc(provider, roll_back_configuration_to_exclude)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-50-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-50-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_rpc(roll_back_configuration_rpc):
-    """Add RPC input data to roll_back_configuration_rpc object."""
+def prepare_roll_back_configuration(roll_back_configuration):
+    """Add RPC input data to roll_back_configuration object."""
     # roll back a specific commit id
-    roll_back_configuration_rpc.input.commit_id = "1000000010"
+    roll_back_configuration.input.commit_id = "1000000010"
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationRpc()  # create object
-    prepare_roll_back_configuration_rpc(roll_back_configuration_rpc)  # add RPC input
+    roll_back_configuration = xr_cfgmgr_rollback_act.RollBackConfiguration()  # create object
+    prepare_roll_back_configuration(roll_back_configuration)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_rpc)
+    executor.execute_rpc(provider, roll_back_configuration)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-52-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-52-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_rpc(roll_back_configuration_rpc):
-    """Add RPC input data to roll_back_configuration_rpc object."""
+def prepare_roll_back_configuration(roll_back_configuration):
+    """Add RPC input data to roll_back_configuration object."""
     # roll back a specific commit id
-    roll_back_configuration_rpc.input.comment = "Simple programmatic rollback"
-    roll_back_configuration_rpc.input.commit_id = "1000000010"
+    roll_back_configuration.input.comment = "Simple programmatic rollback"
+    roll_back_configuration.input.commit_id = "1000000010"
 
 
 
@@ -75,11 +75,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationRpc()  # create object
-    prepare_roll_back_configuration_rpc(roll_back_configuration_rpc)  # add RPC input
+    roll_back_configuration = xr_cfgmgr_rollback_act.RollBackConfiguration()  # create object
+    prepare_roll_back_configuration(roll_back_configuration)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_rpc)
+    executor.execute_rpc(provider, roll_back_configuration)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-54-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-cfgmgr-rollback-act/nc-execute-xr-cfgmgr-rollback-act-54-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_cfgmgr_rollback_act \
 import logging
 
 
-def prepare_roll_back_configuration_rpc(roll_back_configuration_rpc):
-    """Add RPC input data to roll_back_configuration_rpc object."""
+def prepare_roll_back_configuration(roll_back_configuration):
+    """Add RPC input data to roll_back_configuration object."""
     # roll back a specific commit id
-    roll_back_configuration_rpc.input.comment = "Forced programmatic rollback"
-    roll_back_configuration_rpc.input.commit_id = "1000000010"
-    roll_back_configuration_rpc.input.force = True
-    roll_back_configuration_rpc.input.label = "PRB-005"
+    roll_back_configuration.input.comment = "Forced programmatic rollback"
+    roll_back_configuration.input.commit_id = "1000000010"
+    roll_back_configuration.input.force = True
+    roll_back_configuration.input.label = "PRB-005"
 
 
 if __name__ == "__main__":
@@ -76,11 +76,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    roll_back_configuration_rpc = xr_cfgmgr_rollback_act.RollBackConfigurationRpc()  # create object
-    prepare_roll_back_configuration_rpc(roll_back_configuration_rpc)  # add RPC input
+    roll_back_configuration = xr_cfgmgr_rollback_act.RollBackConfiguration()  # create object
+    prepare_roll_back_configuration(roll_back_configuration)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, roll_back_configuration_rpc)
+    executor.execute_rpc(provider, roll_back_configuration)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-10-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, ping_rpc)
+    # executor.execute_rpc(provider, ping)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-20-ydk.py
@@ -38,12 +38,12 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
-    ping_rpc.input.destination.destination = "10.0.0.1"
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
+    ping.input.destination.destination = "10.0.0.1"
 
 
-def process_ping_rpc(ping_rpc):
+def process_ping(ping):
     """Process data in RPC output object."""
     # format string for reply header
     ping_reply_header = ('Sending 5, 100-byte ICMP Echos to {destination}, '
@@ -53,7 +53,7 @@ def process_ping_rpc(ping_rpc):
                           '({hits}/{total}), '
                           'round-trip min/avg/max = {rtt_min}/{rtt_avg}/{rtt_max} ms')
 
-    ping_response = ping_rpc.output.ping_response
+    ping_response = ping.output.ping_response
 
     ping_reply = ping_reply_header.format(destination=ping_response.ipv4[0].destination)
 
@@ -102,12 +102,12 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    ping_rpc.output = executor.execute_rpc(provider, ping_rpc)
-    print(process_ping_rpc(ping_rpc))
+    ping.output = executor.execute_rpc(provider, ping)
+    print(process_ping(ping))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-22-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
-    ping_rpc.input.destination.destination = "10.0.0.1"
-    ping_rpc.input.destination.repeat_count = 10
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
+    ping.input.destination.destination = "10.0.0.1"
+    ping.input.destination.repeat_count = 10
 
 
-def process_ping_rpc(ping_rpc):
+def process_ping(ping):
     """Process data in RPC output object."""
     # format string for reply header
     ping_reply_header = ('Sending 5, 100-byte ICMP Echos to {destination}, '
@@ -54,7 +54,7 @@ def process_ping_rpc(ping_rpc):
                           '({hits}/{total}), '
                           'round-trip min/avg/max = {rtt_min}/{rtt_avg}/{rtt_max} ms')
 
-    ping_response = ping_rpc.output.ping_response
+    ping_response = ping.output.ping_response
 
     ping_reply = ping_reply_header.format(destination=ping_response.ipv4[0].destination)
 
@@ -103,12 +103,12 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    ping_rpc.output = executor.execute_rpc(provider, ping_rpc)
-    print(process_ping_rpc(ping_rpc))
+    ping.output = executor.execute_rpc(provider, ping)
+    print(process_ping(ping))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-24-ydk.py
@@ -38,14 +38,14 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
-    ping_rpc.input.destination.destination = '10.0.0.1'
-    ping_rpc.input.destination.source = 'Loopback0'
-    ping_rpc.input.destination.timeout = 1
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
+    ping.input.destination.destination = '10.0.0.1'
+    ping.input.destination.source = 'Loopback0'
+    ping.input.destination.timeout = 1
 
 
-def process_ping_rpc(ping_rpc):
+def process_ping(ping):
     """Process data in RPC output object."""
     # format string for reply header
     ping_reply_header = ('Sending 5, 100-byte ICMP Echos to {destination}, '
@@ -55,10 +55,10 @@ def process_ping_rpc(ping_rpc):
                           '({hits}/{total}), '
                           'round-trip min/avg/max = {rtt_min}/{rtt_avg}/{rtt_max} ms')
 
-    ping_response = ping_rpc.output.ping_response
+    ping_response = ping.output.ping_response
 
     ping_reply = ping_reply_header.format(destination=ping_response.ipv4[0].destination,
-                                          timeout=ping_rpc.input.destination.timeout)
+                                          timeout=ping.input.destination.timeout)
 
     # iterate over all replies
     for reply in ping_response.ipv4[0].replies.reply:
@@ -105,12 +105,12 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    ping_rpc.output = executor.execute_rpc(provider, ping_rpc)
-    print(process_ping_rpc(ping_rpc))
+    ping.output = executor.execute_rpc(provider, ping)
+    print(process_ping(ping))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-26-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-26-ydk.py
@@ -38,14 +38,14 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
-    ping_rpc.input.destination.destination = '10.0.0.1'
-    ping_rpc.input.destination.data_size = 1500
-    ping_rpc.input.destination.verbose = True
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
+    ping.input.destination.destination = '10.0.0.1'
+    ping.input.destination.data_size = 1500
+    ping.input.destination.verbose = True
 
 
-def process_ping_rpc(ping_rpc):
+def process_ping(ping):
     """Process data in RPC output object."""
     # format string for reply header
     ping_reply_header = ('Sending 5, 100-byte ICMP Echos to {destination}, '
@@ -57,7 +57,7 @@ def process_ping_rpc(ping_rpc):
                           '({hits}/{total}), '
                           'round-trip min/avg/max = {rtt_min}/{rtt_avg}/{rtt_max} ms')
 
-    ping_response = ping_rpc.output.ping_response
+    ping_response = ping.output.ping_response
 
     ping_reply = ping_reply_header.format(destination=ping_response.ipv4[0].destination)
 
@@ -106,12 +106,12 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    ping_rpc.output = executor.execute_rpc(provider, ping_rpc)
-    print(process_ping_rpc(ping_rpc))
+    ping.output = executor.execute_rpc(provider, ping)
+    print(process_ping(ping))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-28-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-ping-act/nc-execute-xr-ping-act-28-ydk.py
@@ -38,13 +38,13 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ping_act \
 import logging
 
 
-def prepare_ping_rpc(ping_rpc):
-    """Add RPC input data to ping_rpc object."""
-    ping_rpc.input.destination.destination = '10.0.0.1'
-    ping_rpc.input.destination.vrf_name = 'RED'
+def prepare_ping(ping):
+    """Add RPC input data to ping object."""
+    ping.input.destination.destination = '10.0.0.1'
+    ping.input.destination.vrf_name = 'RED'
 
 
-def process_ping_rpc(ping_rpc):
+def process_ping(ping):
     """Process data in RPC output object."""
     # format string for reply header
     ping_reply_header = ('Sending 5, 100-byte ICMP Echos to {destination}, '
@@ -54,7 +54,7 @@ def process_ping_rpc(ping_rpc):
                           '({hits}/{total}), '
                           'round-trip min/avg/max = {rtt_min}/{rtt_avg}/{rtt_max} ms')
 
-    ping_response = ping_rpc.output.ping_response
+    ping_response = ping.output.ping_response
 
     ping_reply = ping_reply_header.format(destination=ping_response.ipv4[0].destination)
 
@@ -103,12 +103,12 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    ping_rpc = xr_ping_act.PingRpc()  # create object
-    prepare_ping_rpc(ping_rpc)  # add RPC input
+    ping = xr_ping_act.Ping()  # create object
+    prepare_ping(ping)  # add RPC input
 
     # execute RPC on NETCONF device
-    ping_rpc.output = executor.execute_rpc(provider, ping_rpc)
-    print(process_ping_rpc(ping_rpc))
+    ping.output = executor.execute_rpc(provider, ping)
+    print(process_ping(ping))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-112-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-112-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_interface_link_up_rpc(interface_link_up_rpc):
-    """Add RPC input data to interface_link_up_rpc object."""
+def prepare_interface_link_up(interface_link_up):
+    """Add RPC input data to interface_link_up object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_up_rpc = xr_snmp_test_trap_act.InterfaceLinkUpRpc()  # create object
-    prepare_interface_link_up_rpc(interface_link_up_rpc)  # add RPC input
+    interface_link_up = xr_snmp_test_trap_act.InterfaceLinkUp()  # create object
+    prepare_interface_link_up(interface_link_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, interface_link_up_rpc)
+    # executor.execute_rpc(provider, interface_link_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-113-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-113-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_interface_link_down_rpc(interface_link_down_rpc):
-    """Add RPC input data to interface_link_down_rpc object."""
+def prepare_interface_link_down(interface_link_down):
+    """Add RPC input data to interface_link_down object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_down_rpc = xr_snmp_test_trap_act.InterfaceLinkDownRpc()  # create object
-    prepare_interface_link_down_rpc(interface_link_down_rpc)  # add RPC input
+    interface_link_down = xr_snmp_test_trap_act.InterfaceLinkDown()  # create object
+    prepare_interface_link_down(interface_link_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, interface_link_down_rpc)
+    # executor.execute_rpc(provider, interface_link_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-114-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-114-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_section_status_rpc(sonet_section_status_rpc):
-    """Add RPC input data to sonet_section_status_rpc object."""
+def prepare_sonet_section_status(sonet_section_status):
+    """Add RPC input data to sonet_section_status object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_section_status_rpc = xr_snmp_test_trap_act.SonetSectionStatusRpc()  # create object
-    prepare_sonet_section_status_rpc(sonet_section_status_rpc)  # add RPC input
+    sonet_section_status = xr_snmp_test_trap_act.SonetSectionStatus()  # create object
+    prepare_sonet_section_status(sonet_section_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, sonet_section_status_rpc)
+    # executor.execute_rpc(provider, sonet_section_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-115-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-115-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_line_status_rpc(sonet_line_status_rpc):
-    """Add RPC input data to sonet_line_status_rpc object."""
+def prepare_sonet_line_status(sonet_line_status):
+    """Add RPC input data to sonet_line_status object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_line_status_rpc = xr_snmp_test_trap_act.SonetLineStatusRpc()  # create object
-    prepare_sonet_line_status_rpc(sonet_line_status_rpc)  # add RPC input
+    sonet_line_status = xr_snmp_test_trap_act.SonetLineStatus()  # create object
+    prepare_sonet_line_status(sonet_line_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, sonet_line_status_rpc)
+    # executor.execute_rpc(provider, sonet_line_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-116-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-116-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_path_status_rpc(sonet_path_status_rpc):
-    """Add RPC input data to sonet_path_status_rpc object."""
+def prepare_sonet_path_status(sonet_path_status):
+    """Add RPC input data to sonet_path_status object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_path_status_rpc = xr_snmp_test_trap_act.SonetPathStatusRpc()  # create object
-    prepare_sonet_path_status_rpc(sonet_path_status_rpc)  # add RPC input
+    sonet_path_status = xr_snmp_test_trap_act.SonetPathStatus()  # create object
+    prepare_sonet_path_status(sonet_path_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, sonet_path_status_rpc)
+    # executor.execute_rpc(provider, sonet_path_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-125-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-125-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_sensor_threshold_notification_rpc(entity_sensor_threshold_notification_rpc):
-    """Add RPC input data to entity_sensor_threshold_notification_rpc object."""
+def prepare_entity_sensor_threshold_notification(entity_sensor_threshold_notification):
+    """Add RPC input data to entity_sensor_threshold_notification object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_sensor_threshold_notification_rpc = xr_snmp_test_trap_act.EntitySensorThresholdNotificationRpc()  # create object
-    prepare_entity_sensor_threshold_notification_rpc(entity_sensor_threshold_notification_rpc)  # add RPC input
+    entity_sensor_threshold_notification = xr_snmp_test_trap_act.EntitySensorThresholdNotification()  # create object
+    prepare_entity_sensor_threshold_notification(entity_sensor_threshold_notification)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_sensor_threshold_notification_rpc)
+    # executor.execute_rpc(provider, entity_sensor_threshold_notification)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-126-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-126-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_power_status_change_failed_rpc(entity_fru_power_status_change_failed_rpc):
-    """Add RPC input data to entity_fru_power_status_change_failed_rpc object."""
+def prepare_entity_fru_power_status_change_failed(entity_fru_power_status_change_failed):
+    """Add RPC input data to entity_fru_power_status_change_failed object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_power_status_change_failed_rpc = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailedRpc()  # create object
-    prepare_entity_fru_power_status_change_failed_rpc(entity_fru_power_status_change_failed_rpc)  # add RPC input
+    entity_fru_power_status_change_failed = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailed()  # create object
+    prepare_entity_fru_power_status_change_failed(entity_fru_power_status_change_failed)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_power_status_change_failed_rpc)
+    # executor.execute_rpc(provider, entity_fru_power_status_change_failed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-127-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-127-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_module_status_change_up_rpc(entity_fru_module_status_change_up_rpc):
-    """Add RPC input data to entity_fru_module_status_change_up_rpc object."""
+def prepare_entity_fru_module_status_change_up(entity_fru_module_status_change_up):
+    """Add RPC input data to entity_fru_module_status_change_up object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_up_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUpRpc()  # create object
-    prepare_entity_fru_module_status_change_up_rpc(entity_fru_module_status_change_up_rpc)  # add RPC input
+    entity_fru_module_status_change_up = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUp()  # create object
+    prepare_entity_fru_module_status_change_up(entity_fru_module_status_change_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_module_status_change_up_rpc)
+    # executor.execute_rpc(provider, entity_fru_module_status_change_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-128-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-128-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_module_status_change_down_rpc(entity_fru_module_status_change_down_rpc):
-    """Add RPC input data to entity_fru_module_status_change_down_rpc object."""
+def prepare_entity_fru_module_status_change_down(entity_fru_module_status_change_down):
+    """Add RPC input data to entity_fru_module_status_change_down object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_down_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDownRpc()  # create object
-    prepare_entity_fru_module_status_change_down_rpc(entity_fru_module_status_change_down_rpc)  # add RPC input
+    entity_fru_module_status_change_down = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDown()  # create object
+    prepare_entity_fru_module_status_change_down(entity_fru_module_status_change_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_module_status_change_down_rpc)
+    # executor.execute_rpc(provider, entity_fru_module_status_change_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-129-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-129-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_oper_status_up_rpc(entity_fru_fan_tray_oper_status_up_rpc):
-    """Add RPC input data to entity_fru_fan_tray_oper_status_up_rpc object."""
+def prepare_entity_fru_fan_tray_oper_status_up(entity_fru_fan_tray_oper_status_up):
+    """Add RPC input data to entity_fru_fan_tray_oper_status_up object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_oper_status_up_rpc = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUpRpc()  # create object
-    prepare_entity_fru_fan_tray_oper_status_up_rpc(entity_fru_fan_tray_oper_status_up_rpc)  # add RPC input
+    entity_fru_fan_tray_oper_status_up = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUp()  # create object
+    prepare_entity_fru_fan_tray_oper_status_up(entity_fru_fan_tray_oper_status_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up_rpc)
+    # executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-130-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-130-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_inserted_rpc(entity_fru_fan_tray_inserted_rpc):
-    """Add RPC input data to entity_fru_fan_tray_inserted_rpc object."""
+def prepare_entity_fru_fan_tray_inserted(entity_fru_fan_tray_inserted):
+    """Add RPC input data to entity_fru_fan_tray_inserted object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_inserted_rpc = xr_snmp_test_trap_act.EntityFruFanTrayInsertedRpc()  # create object
-    prepare_entity_fru_fan_tray_inserted_rpc(entity_fru_fan_tray_inserted_rpc)  # add RPC input
+    entity_fru_fan_tray_inserted = xr_snmp_test_trap_act.EntityFruFanTrayInserted()  # create object
+    prepare_entity_fru_fan_tray_inserted(entity_fru_fan_tray_inserted)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_fan_tray_inserted_rpc)
+    # executor.execute_rpc(provider, entity_fru_fan_tray_inserted)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-131-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-131-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_removed_rpc(entity_fru_fan_tray_removed_rpc):
-    """Add RPC input data to entity_fru_fan_tray_removed_rpc object."""
+def prepare_entity_fru_fan_tray_removed(entity_fru_fan_tray_removed):
+    """Add RPC input data to entity_fru_fan_tray_removed object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_removed_rpc = xr_snmp_test_trap_act.EntityFruFanTrayRemovedRpc()  # create object
-    prepare_entity_fru_fan_tray_removed_rpc(entity_fru_fan_tray_removed_rpc)  # add RPC input
+    entity_fru_fan_tray_removed = xr_snmp_test_trap_act.EntityFruFanTrayRemoved()  # create object
+    prepare_entity_fru_fan_tray_removed(entity_fru_fan_tray_removed)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, entity_fru_fan_tray_removed_rpc)
+    # executor.execute_rpc(provider, entity_fru_fan_tray_removed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-132-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-132-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_bundle_downed_link_rpc(platform_hfr_bundle_downed_link_rpc):
-    """Add RPC input data to platform_hfr_bundle_downed_link_rpc object."""
+def prepare_platform_hfr_bundle_downed_link(platform_hfr_bundle_downed_link):
+    """Add RPC input data to platform_hfr_bundle_downed_link object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_downed_link_rpc = xr_snmp_test_trap_act.PlatformHfrBundleDownedLinkRpc()  # create object
-    prepare_platform_hfr_bundle_downed_link_rpc(platform_hfr_bundle_downed_link_rpc)  # add RPC input
+    platform_hfr_bundle_downed_link = xr_snmp_test_trap_act.PlatformHfrBundleDownedLink()  # create object
+    prepare_platform_hfr_bundle_downed_link(platform_hfr_bundle_downed_link)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, platform_hfr_bundle_downed_link_rpc)
+    # executor.execute_rpc(provider, platform_hfr_bundle_downed_link)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-133-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-133-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_bundle_state_rpc(platform_hfr_bundle_state_rpc):
-    """Add RPC input data to platform_hfr_bundle_state_rpc object."""
+def prepare_platform_hfr_bundle_state(platform_hfr_bundle_state):
+    """Add RPC input data to platform_hfr_bundle_state object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_state_rpc = xr_snmp_test_trap_act.PlatformHfrBundleStateRpc()  # create object
-    prepare_platform_hfr_bundle_state_rpc(platform_hfr_bundle_state_rpc)  # add RPC input
+    platform_hfr_bundle_state = xr_snmp_test_trap_act.PlatformHfrBundleState()  # create object
+    prepare_platform_hfr_bundle_state(platform_hfr_bundle_state)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, platform_hfr_bundle_state_rpc)
+    # executor.execute_rpc(provider, platform_hfr_bundle_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-134-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-134-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_plane_state_rpc(platform_hfr_plane_state_rpc):
-    """Add RPC input data to platform_hfr_plane_state_rpc object."""
+def prepare_platform_hfr_plane_state(platform_hfr_plane_state):
+    """Add RPC input data to platform_hfr_plane_state object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_plane_state_rpc = xr_snmp_test_trap_act.PlatformHfrPlaneStateRpc()  # create object
-    prepare_platform_hfr_plane_state_rpc(platform_hfr_plane_state_rpc)  # add RPC input
+    platform_hfr_plane_state = xr_snmp_test_trap_act.PlatformHfrPlaneState()  # create object
+    prepare_platform_hfr_plane_state(platform_hfr_plane_state)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, platform_hfr_plane_state_rpc)
+    # executor.execute_rpc(provider, platform_hfr_plane_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-135-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-135-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_bgp_established_remote_peer_rpc(routing_bgp_established_remote_peer_rpc):
-    """Add RPC input data to routing_bgp_established_remote_peer_rpc object."""
+def prepare_routing_bgp_established_remote_peer(routing_bgp_established_remote_peer):
+    """Add RPC input data to routing_bgp_established_remote_peer object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_established_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeerRpc()  # create object
-    prepare_routing_bgp_established_remote_peer_rpc(routing_bgp_established_remote_peer_rpc)  # add RPC input
+    routing_bgp_established_remote_peer = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeer()  # create object
+    prepare_routing_bgp_established_remote_peer(routing_bgp_established_remote_peer)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_bgp_established_remote_peer_rpc)
+    # executor.execute_rpc(provider, routing_bgp_established_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-136-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-136-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_bgp_state_change_remote_peer_rpc(routing_bgp_state_change_remote_peer_rpc):
-    """Add RPC input data to routing_bgp_state_change_remote_peer_rpc object."""
+def prepare_routing_bgp_state_change_remote_peer(routing_bgp_state_change_remote_peer):
+    """Add RPC input data to routing_bgp_state_change_remote_peer object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_state_change_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeerRpc()  # create object
-    prepare_routing_bgp_state_change_remote_peer_rpc(routing_bgp_state_change_remote_peer_rpc)  # add RPC input
+    routing_bgp_state_change_remote_peer = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeer()  # create object
+    prepare_routing_bgp_state_change_remote_peer(routing_bgp_state_change_remote_peer)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_bgp_state_change_remote_peer_rpc)
+    # executor.execute_rpc(provider, routing_bgp_state_change_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-137-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-137-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc):
-    """Add RPC input data to routing_ospf_neighbor_state_change_rpc object."""
+def prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change):
+    """Add RPC input data to routing_ospf_neighbor_state_change object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_ospf_neighbor_state_change_rpc = xr_snmp_test_trap_act.RoutingOspfNeighborStateChangeRpc()  # create object
-    prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc)  # add RPC input
+    routing_ospf_neighbor_state_change = xr_snmp_test_trap_act.RoutingOspfNeighborStateChange()  # create object
+    prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_ospf_neighbor_state_change_rpc)
+    # executor.execute_rpc(provider, routing_ospf_neighbor_state_change)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-138-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-138-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_ldp_session_down_rpc(routing_mpls_ldp_session_down_rpc):
-    """Add RPC input data to routing_mpls_ldp_session_down_rpc object."""
+def prepare_routing_mpls_ldp_session_down(routing_mpls_ldp_session_down):
+    """Add RPC input data to routing_mpls_ldp_session_down object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_ldp_session_down_rpc = xr_snmp_test_trap_act.RoutingMplsLdpSessionDownRpc()  # create object
-    prepare_routing_mpls_ldp_session_down_rpc(routing_mpls_ldp_session_down_rpc)  # add RPC input
+    routing_mpls_ldp_session_down = xr_snmp_test_trap_act.RoutingMplsLdpSessionDown()  # create object
+    prepare_routing_mpls_ldp_session_down(routing_mpls_ldp_session_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_mpls_ldp_session_down_rpc)
+    # executor.execute_rpc(provider, routing_mpls_ldp_session_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-139-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-139-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_re_routed_rpc(routing_mpls_tunnel_re_routed_rpc):
-    """Add RPC input data to routing_mpls_tunnel_re_routed_rpc object."""
+def prepare_routing_mpls_tunnel_re_routed(routing_mpls_tunnel_re_routed):
+    """Add RPC input data to routing_mpls_tunnel_re_routed object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_routed_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReRoutedRpc()  # create object
-    prepare_routing_mpls_tunnel_re_routed_rpc(routing_mpls_tunnel_re_routed_rpc)  # add RPC input
+    routing_mpls_tunnel_re_routed = xr_snmp_test_trap_act.RoutingMplsTunnelReRouted()  # create object
+    prepare_routing_mpls_tunnel_re_routed(routing_mpls_tunnel_re_routed)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_mpls_tunnel_re_routed_rpc)
+    # executor.execute_rpc(provider, routing_mpls_tunnel_re_routed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-140-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-140-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_re_optimized_rpc(routing_mpls_tunnel_re_optimized_rpc):
-    """Add RPC input data to routing_mpls_tunnel_re_optimized_rpc object."""
+def prepare_routing_mpls_tunnel_re_optimized(routing_mpls_tunnel_re_optimized):
+    """Add RPC input data to routing_mpls_tunnel_re_optimized object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_optimized_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimizedRpc()  # create object
-    prepare_routing_mpls_tunnel_re_optimized_rpc(routing_mpls_tunnel_re_optimized_rpc)  # add RPC input
+    routing_mpls_tunnel_re_optimized = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimized()  # create object
+    prepare_routing_mpls_tunnel_re_optimized(routing_mpls_tunnel_re_optimized)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized_rpc)
+    # executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-141-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-141-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_down_rpc(routing_mpls_tunnel_down_rpc):
-    """Add RPC input data to routing_mpls_tunnel_down_rpc object."""
+def prepare_routing_mpls_tunnel_down(routing_mpls_tunnel_down):
+    """Add RPC input data to routing_mpls_tunnel_down object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_down_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelDownRpc()  # create object
-    prepare_routing_mpls_tunnel_down_rpc(routing_mpls_tunnel_down_rpc)  # add RPC input
+    routing_mpls_tunnel_down = xr_snmp_test_trap_act.RoutingMplsTunnelDown()  # create object
+    prepare_routing_mpls_tunnel_down(routing_mpls_tunnel_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, routing_mpls_tunnel_down_rpc)
+    # executor.execute_rpc(provider, routing_mpls_tunnel_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-200-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-200-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    snmp_cold_start_rpc = xr_snmp_test_trap_act.SnmpColdStartRpc()  # create object
+    snmp_cold_start = xr_snmp_test_trap_act.SnmpColdStart()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, snmp_cold_start_rpc)
+    executor.execute_rpc(provider, snmp_cold_start)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-201-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-201-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    snmp_warm_start_rpc = xr_snmp_test_trap_act.SnmpWarmStartRpc()  # create object
+    snmp_warm_start = xr_snmp_test_trap_act.SnmpWarmStart()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, snmp_warm_start_rpc)
+    executor.execute_rpc(provider, snmp_warm_start)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-210-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-210-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_syslog_message_generated_rpc = xr_snmp_test_trap_act.InfraSyslogMessageGeneratedRpc()  # create object
+    infra_syslog_message_generated = xr_snmp_test_trap_act.InfraSyslogMessageGenerated()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_syslog_message_generated_rpc)
+    executor.execute_rpc(provider, infra_syslog_message_generated)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-211-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-211-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_flash_device_inserted_rpc = xr_snmp_test_trap_act.InfraFlashDeviceInsertedRpc()  # create object
+    infra_flash_device_inserted = xr_snmp_test_trap_act.InfraFlashDeviceInserted()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_flash_device_inserted_rpc)
+    executor.execute_rpc(provider, infra_flash_device_inserted)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-212-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-212-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_flash_device_removed_rpc = xr_snmp_test_trap_act.InfraFlashDeviceRemovedRpc()  # create object
+    infra_flash_device_removed = xr_snmp_test_trap_act.InfraFlashDeviceRemoved()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_flash_device_removed_rpc)
+    executor.execute_rpc(provider, infra_flash_device_removed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-213-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-213-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_redundancy_progression_rpc = xr_snmp_test_trap_act.InfraRedundancyProgressionRpc()  # create object
+    infra_redundancy_progression = xr_snmp_test_trap_act.InfraRedundancyProgression()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_redundancy_progression_rpc)
+    executor.execute_rpc(provider, infra_redundancy_progression)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-214-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-214-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_redundancy_switch_rpc = xr_snmp_test_trap_act.InfraRedundancySwitchRpc()  # create object
+    infra_redundancy_switch = xr_snmp_test_trap_act.InfraRedundancySwitch()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_redundancy_switch_rpc)
+    executor.execute_rpc(provider, infra_redundancy_switch)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-215-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-215-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_bridge_new_root_rpc = xr_snmp_test_trap_act.InfraBridgeNewRootRpc()  # create object
+    infra_bridge_new_root = xr_snmp_test_trap_act.InfraBridgeNewRoot()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_bridge_new_root_rpc)
+    executor.execute_rpc(provider, infra_bridge_new_root)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-216-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-216-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_bridge_topology_change_rpc = xr_snmp_test_trap_act.InfraBridgeTopologyChangeRpc()  # create object
+    infra_bridge_topology_change = xr_snmp_test_trap_act.InfraBridgeTopologyChange()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_bridge_topology_change_rpc)
+    executor.execute_rpc(provider, infra_bridge_topology_change)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-217-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-217-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    infra_config_event_rpc = xr_snmp_test_trap_act.InfraConfigEventRpc()  # create object
+    infra_config_event = xr_snmp_test_trap_act.InfraConfigEvent()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, infra_config_event_rpc)
+    executor.execute_rpc(provider, infra_config_event)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-300-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-300-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_up_rpc = xr_snmp_test_trap_act.InterfaceLinkUpRpc()  # create object
+    interface_link_up = xr_snmp_test_trap_act.InterfaceLinkUp()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, interface_link_up_rpc)
+    executor.execute_rpc(provider, interface_link_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-302-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-302-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_interface_link_up_rpc(interface_link_up_rpc):
-    """Add RPC input data to interface_link_up_rpc object."""
-    interface_link_up_rpc.input.ifindex = 3
+def prepare_interface_link_up(interface_link_up):
+    """Add RPC input data to interface_link_up object."""
+    interface_link_up.input.ifindex = 3
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_up_rpc = xr_snmp_test_trap_act.InterfaceLinkUpRpc()  # create object
-    prepare_interface_link_up_rpc(interface_link_up_rpc)  # add RPC input
+    interface_link_up = xr_snmp_test_trap_act.InterfaceLinkUp()  # create object
+    prepare_interface_link_up(interface_link_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, interface_link_up_rpc)
+    executor.execute_rpc(provider, interface_link_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-304-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-304-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_down_rpc = xr_snmp_test_trap_act.InterfaceLinkDownRpc()  # create object
+    interface_link_down = xr_snmp_test_trap_act.InterfaceLinkDown()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, interface_link_down_rpc)
+    executor.execute_rpc(provider, interface_link_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-306-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-306-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_interface_link_down_rpc(interface_link_down_rpc):
-    """Add RPC input data to interface_link_down_rpc object."""
-    interface_link_down_rpc.input.ifindex = 3
+def prepare_interface_link_down(interface_link_down):
+    """Add RPC input data to interface_link_down object."""
+    interface_link_down.input.ifindex = 3
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    interface_link_down_rpc = xr_snmp_test_trap_act.InterfaceLinkDownRpc()  # create object
-    prepare_interface_link_down_rpc(interface_link_down_rpc)  # add RPC input
+    interface_link_down = xr_snmp_test_trap_act.InterfaceLinkDown()  # create object
+    prepare_interface_link_down(interface_link_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, interface_link_down_rpc)
+    executor.execute_rpc(provider, interface_link_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-308-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-308-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_section_status_rpc = xr_snmp_test_trap_act.SonetSectionStatusRpc()  # create object
+    sonet_section_status = xr_snmp_test_trap_act.SonetSectionStatus()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_section_status_rpc)
+    executor.execute_rpc(provider, sonet_section_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-310-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-310-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_section_status_rpc(sonet_section_status_rpc):
-    """Add RPC input data to sonet_section_status_rpc object."""
-    sonet_section_status_rpc.input.ifindex = 5
+def prepare_sonet_section_status(sonet_section_status):
+    """Add RPC input data to sonet_section_status object."""
+    sonet_section_status.input.ifindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_section_status_rpc = xr_snmp_test_trap_act.SonetSectionStatusRpc()  # create object
-    prepare_sonet_section_status_rpc(sonet_section_status_rpc)  # add RPC input
+    sonet_section_status = xr_snmp_test_trap_act.SonetSectionStatus()  # create object
+    prepare_sonet_section_status(sonet_section_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_section_status_rpc)
+    executor.execute_rpc(provider, sonet_section_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-312-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-312-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_line_status_rpc = xr_snmp_test_trap_act.SonetLineStatusRpc()  # create object
+    sonet_line_status = xr_snmp_test_trap_act.SonetLineStatus()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_line_status_rpc)
+    executor.execute_rpc(provider, sonet_line_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-314-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-314-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_line_status_rpc(sonet_line_status_rpc):
-    """Add RPC input data to sonet_line_status_rpc object."""
-    sonet_line_status_rpc.input.ifindex = 5
+def prepare_sonet_line_status(sonet_line_status):
+    """Add RPC input data to sonet_line_status object."""
+    sonet_line_status.input.ifindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_line_status_rpc = xr_snmp_test_trap_act.SonetLineStatusRpc()  # create object
-    prepare_sonet_line_status_rpc(sonet_line_status_rpc)  # add RPC input
+    sonet_line_status = xr_snmp_test_trap_act.SonetLineStatus()  # create object
+    prepare_sonet_line_status(sonet_line_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_line_status_rpc)
+    executor.execute_rpc(provider, sonet_line_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-316-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-316-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_path_status_rpc = xr_snmp_test_trap_act.SonetPathStatusRpc()  # create object
+    sonet_path_status = xr_snmp_test_trap_act.SonetPathStatus()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_path_status_rpc)
+    executor.execute_rpc(provider, sonet_path_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-318-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-318-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_sonet_path_status_rpc(sonet_path_status_rpc):
-    """Add RPC input data to sonet_path_status_rpc object."""
-    sonet_path_status_rpc.input.ifindex = 5
+def prepare_sonet_path_status(sonet_path_status):
+    """Add RPC input data to sonet_path_status object."""
+    sonet_path_status.input.ifindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    sonet_path_status_rpc = xr_snmp_test_trap_act.SonetPathStatusRpc()  # create object
-    prepare_sonet_path_status_rpc(sonet_path_status_rpc)  # add RPC input
+    sonet_path_status = xr_snmp_test_trap_act.SonetPathStatus()  # create object
+    prepare_sonet_path_status(sonet_path_status)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, sonet_path_status_rpc)
+    executor.execute_rpc(provider, sonet_path_status)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-400-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-400-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_sensor_threshold_notification_rpc = xr_snmp_test_trap_act.EntitySensorThresholdNotificationRpc()  # create object
+    entity_sensor_threshold_notification = xr_snmp_test_trap_act.EntitySensorThresholdNotification()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_sensor_threshold_notification_rpc)
+    executor.execute_rpc(provider, entity_sensor_threshold_notification)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-402-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-402-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_sensor_threshold_notification_rpc(entity_sensor_threshold_notification_rpc):
-    """Add RPC input data to entity_sensor_threshold_notification_rpc object."""
-    entity_sensor_threshold_notification_rpc.input.entindex = 5
+def prepare_entity_sensor_threshold_notification(entity_sensor_threshold_notification):
+    """Add RPC input data to entity_sensor_threshold_notification object."""
+    entity_sensor_threshold_notification.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_sensor_threshold_notification_rpc = xr_snmp_test_trap_act.EntitySensorThresholdNotificationRpc()  # create object
-    prepare_entity_sensor_threshold_notification_rpc(entity_sensor_threshold_notification_rpc)  # add RPC input
+    entity_sensor_threshold_notification = xr_snmp_test_trap_act.EntitySensorThresholdNotification()  # create object
+    prepare_entity_sensor_threshold_notification(entity_sensor_threshold_notification)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_sensor_threshold_notification_rpc)
+    executor.execute_rpc(provider, entity_sensor_threshold_notification)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-404-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-404-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_power_status_change_failed_rpc = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailedRpc()  # create object
+    entity_fru_power_status_change_failed = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailed()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_power_status_change_failed_rpc)
+    executor.execute_rpc(provider, entity_fru_power_status_change_failed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-406-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-406-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_power_status_change_failed_rpc(entity_fru_power_status_change_failed_rpc):
-    """Add RPC input data to entity_fru_power_status_change_failed_rpc object."""
-    entity_fru_power_status_change_failed_rpc.input.entindex = 5
+def prepare_entity_fru_power_status_change_failed(entity_fru_power_status_change_failed):
+    """Add RPC input data to entity_fru_power_status_change_failed object."""
+    entity_fru_power_status_change_failed.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_power_status_change_failed_rpc = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailedRpc()  # create object
-    prepare_entity_fru_power_status_change_failed_rpc(entity_fru_power_status_change_failed_rpc)  # add RPC input
+    entity_fru_power_status_change_failed = xr_snmp_test_trap_act.EntityFruPowerStatusChangeFailed()  # create object
+    prepare_entity_fru_power_status_change_failed(entity_fru_power_status_change_failed)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_power_status_change_failed_rpc)
+    executor.execute_rpc(provider, entity_fru_power_status_change_failed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-408-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-408-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_up_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUpRpc()  # create object
+    entity_fru_module_status_change_up = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUp()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_module_status_change_up_rpc)
+    executor.execute_rpc(provider, entity_fru_module_status_change_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-410-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-410-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_module_status_change_up_rpc(entity_fru_module_status_change_up_rpc):
-    """Add RPC input data to entity_fru_module_status_change_up_rpc object."""
-    entity_fru_module_status_change_up_rpc.input.entindex = 5
+def prepare_entity_fru_module_status_change_up(entity_fru_module_status_change_up):
+    """Add RPC input data to entity_fru_module_status_change_up object."""
+    entity_fru_module_status_change_up.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_up_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUpRpc()  # create object
-    prepare_entity_fru_module_status_change_up_rpc(entity_fru_module_status_change_up_rpc)  # add RPC input
+    entity_fru_module_status_change_up = xr_snmp_test_trap_act.EntityFruModuleStatusChangeUp()  # create object
+    prepare_entity_fru_module_status_change_up(entity_fru_module_status_change_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_module_status_change_up_rpc)
+    executor.execute_rpc(provider, entity_fru_module_status_change_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-412-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-412-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_down_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDownRpc()  # create object
+    entity_fru_module_status_change_down = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDown()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_module_status_change_down_rpc)
+    executor.execute_rpc(provider, entity_fru_module_status_change_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-414-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-414-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_module_status_change_down_rpc(entity_fru_module_status_change_down_rpc):
-    """Add RPC input data to entity_fru_module_status_change_down_rpc object."""
-    entity_fru_module_status_change_down_rpc.input.entindex = 5
+def prepare_entity_fru_module_status_change_down(entity_fru_module_status_change_down):
+    """Add RPC input data to entity_fru_module_status_change_down object."""
+    entity_fru_module_status_change_down.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_module_status_change_down_rpc = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDownRpc()  # create object
-    prepare_entity_fru_module_status_change_down_rpc(entity_fru_module_status_change_down_rpc)  # add RPC input
+    entity_fru_module_status_change_down = xr_snmp_test_trap_act.EntityFruModuleStatusChangeDown()  # create object
+    prepare_entity_fru_module_status_change_down(entity_fru_module_status_change_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_module_status_change_down_rpc)
+    executor.execute_rpc(provider, entity_fru_module_status_change_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-416-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-416-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_oper_status_up_rpc = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUpRpc()  # create object
+    entity_fru_fan_tray_oper_status_up = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUp()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-418-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-418-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_oper_status_up_rpc(entity_fru_fan_tray_oper_status_up_rpc):
-    """Add RPC input data to entity_fru_fan_tray_oper_status_up_rpc object."""
-    entity_fru_fan_tray_oper_status_up_rpc.input.entindex = 5
+def prepare_entity_fru_fan_tray_oper_status_up(entity_fru_fan_tray_oper_status_up):
+    """Add RPC input data to entity_fru_fan_tray_oper_status_up object."""
+    entity_fru_fan_tray_oper_status_up.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_oper_status_up_rpc = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUpRpc()  # create object
-    prepare_entity_fru_fan_tray_oper_status_up_rpc(entity_fru_fan_tray_oper_status_up_rpc)  # add RPC input
+    entity_fru_fan_tray_oper_status_up = xr_snmp_test_trap_act.EntityFruFanTrayOperStatusUp()  # create object
+    prepare_entity_fru_fan_tray_oper_status_up(entity_fru_fan_tray_oper_status_up)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_oper_status_up)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-420-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-420-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_inserted_rpc = xr_snmp_test_trap_act.EntityFruFanTrayInsertedRpc()  # create object
+    entity_fru_fan_tray_inserted = xr_snmp_test_trap_act.EntityFruFanTrayInserted()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_inserted_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_inserted)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-422-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-422-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_inserted_rpc(entity_fru_fan_tray_inserted_rpc):
-    """Add RPC input data to entity_fru_fan_tray_inserted_rpc object."""
-    entity_fru_fan_tray_inserted_rpc.input.entindex = 5
+def prepare_entity_fru_fan_tray_inserted(entity_fru_fan_tray_inserted):
+    """Add RPC input data to entity_fru_fan_tray_inserted object."""
+    entity_fru_fan_tray_inserted.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_inserted_rpc = xr_snmp_test_trap_act.EntityFruFanTrayInsertedRpc()  # create object
-    prepare_entity_fru_fan_tray_inserted_rpc(entity_fru_fan_tray_inserted_rpc)  # add RPC input
+    entity_fru_fan_tray_inserted = xr_snmp_test_trap_act.EntityFruFanTrayInserted()  # create object
+    prepare_entity_fru_fan_tray_inserted(entity_fru_fan_tray_inserted)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_inserted_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_inserted)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-424-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-424-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_removed_rpc = xr_snmp_test_trap_act.EntityFruFanTrayRemovedRpc()  # create object
+    entity_fru_fan_tray_removed = xr_snmp_test_trap_act.EntityFruFanTrayRemoved()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_removed_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_removed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-426-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-426-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_entity_fru_fan_tray_removed_rpc(entity_fru_fan_tray_removed_rpc):
-    """Add RPC input data to entity_fru_fan_tray_removed_rpc object."""
-    entity_fru_fan_tray_removed_rpc.input.entindex = 5
+def prepare_entity_fru_fan_tray_removed(entity_fru_fan_tray_removed):
+    """Add RPC input data to entity_fru_fan_tray_removed object."""
+    entity_fru_fan_tray_removed.input.entindex = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    entity_fru_fan_tray_removed_rpc = xr_snmp_test_trap_act.EntityFruFanTrayRemovedRpc()  # create object
-    prepare_entity_fru_fan_tray_removed_rpc(entity_fru_fan_tray_removed_rpc)  # add RPC input
+    entity_fru_fan_tray_removed = xr_snmp_test_trap_act.EntityFruFanTrayRemoved()  # create object
+    prepare_entity_fru_fan_tray_removed(entity_fru_fan_tray_removed)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, entity_fru_fan_tray_removed_rpc)
+    executor.execute_rpc(provider, entity_fru_fan_tray_removed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-440-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-440-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_downed_link_rpc = xr_snmp_test_trap_act.PlatformHfrBundleDownedLinkRpc()  # create object
+    platform_hfr_bundle_downed_link = xr_snmp_test_trap_act.PlatformHfrBundleDownedLink()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_bundle_downed_link_rpc)
+    executor.execute_rpc(provider, platform_hfr_bundle_downed_link)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-442-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-442-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_bundle_downed_link_rpc(platform_hfr_bundle_downed_link_rpc):
-    """Add RPC input data to platform_hfr_bundle_downed_link_rpc object."""
-    platform_hfr_bundle_downed_link_rpc.input.bundle_name = "F0/SM0/FM/0"
+def prepare_platform_hfr_bundle_downed_link(platform_hfr_bundle_downed_link):
+    """Add RPC input data to platform_hfr_bundle_downed_link object."""
+    platform_hfr_bundle_downed_link.input.bundle_name = "F0/SM0/FM/0"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_downed_link_rpc = xr_snmp_test_trap_act.PlatformHfrBundleDownedLinkRpc()  # create object
-    prepare_platform_hfr_bundle_downed_link_rpc(platform_hfr_bundle_downed_link_rpc)  # add RPC input
+    platform_hfr_bundle_downed_link = xr_snmp_test_trap_act.PlatformHfrBundleDownedLink()  # create object
+    prepare_platform_hfr_bundle_downed_link(platform_hfr_bundle_downed_link)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_bundle_downed_link_rpc)
+    executor.execute_rpc(provider, platform_hfr_bundle_downed_link)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-444-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-444-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_state_rpc = xr_snmp_test_trap_act.PlatformHfrBundleStateRpc()  # create object
+    platform_hfr_bundle_state = xr_snmp_test_trap_act.PlatformHfrBundleState()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_bundle_state_rpc)
+    executor.execute_rpc(provider, platform_hfr_bundle_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-446-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-446-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_bundle_state_rpc(platform_hfr_bundle_state_rpc):
-    """Add RPC input data to platform_hfr_bundle_state_rpc object."""
-    platform_hfr_bundle_state_rpc.input.bundle_name = "F0/SM0/FM/0"
+def prepare_platform_hfr_bundle_state(platform_hfr_bundle_state):
+    """Add RPC input data to platform_hfr_bundle_state object."""
+    platform_hfr_bundle_state.input.bundle_name = "F0/SM0/FM/0"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_bundle_state_rpc = xr_snmp_test_trap_act.PlatformHfrBundleStateRpc()  # create object
-    prepare_platform_hfr_bundle_state_rpc(platform_hfr_bundle_state_rpc)  # add RPC input
+    platform_hfr_bundle_state = xr_snmp_test_trap_act.PlatformHfrBundleState()  # create object
+    prepare_platform_hfr_bundle_state(platform_hfr_bundle_state)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_bundle_state_rpc)
+    executor.execute_rpc(provider, platform_hfr_bundle_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-448-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-448-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_plane_state_rpc = xr_snmp_test_trap_act.PlatformHfrPlaneStateRpc()  # create object
+    platform_hfr_plane_state = xr_snmp_test_trap_act.PlatformHfrPlaneState()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_plane_state_rpc)
+    executor.execute_rpc(provider, platform_hfr_plane_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-450-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-450-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_platform_hfr_plane_state_rpc(platform_hfr_plane_state_rpc):
-    """Add RPC input data to platform_hfr_plane_state_rpc object."""
-    platform_hfr_plane_state_rpc.input.plane_id = 5
+def prepare_platform_hfr_plane_state(platform_hfr_plane_state):
+    """Add RPC input data to platform_hfr_plane_state object."""
+    platform_hfr_plane_state.input.plane_id = 5
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    platform_hfr_plane_state_rpc = xr_snmp_test_trap_act.PlatformHfrPlaneStateRpc()  # create object
-    prepare_platform_hfr_plane_state_rpc(platform_hfr_plane_state_rpc)  # add RPC input
+    platform_hfr_plane_state = xr_snmp_test_trap_act.PlatformHfrPlaneState()  # create object
+    prepare_platform_hfr_plane_state(platform_hfr_plane_state)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, platform_hfr_plane_state_rpc)
+    executor.execute_rpc(provider, platform_hfr_plane_state)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-500-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-500-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_established_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeerRpc()  # create object
+    routing_bgp_established_remote_peer = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeer()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_bgp_established_remote_peer_rpc)
+    executor.execute_rpc(provider, routing_bgp_established_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-502-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-502-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_bgp_established_remote_peer_rpc(routing_bgp_established_remote_peer_rpc):
-    """Add RPC input data to routing_bgp_established_remote_peer_rpc object."""
-    routing_bgp_established_remote_peer_rpc.input.address = "172.16.255.2"
+def prepare_routing_bgp_established_remote_peer(routing_bgp_established_remote_peer):
+    """Add RPC input data to routing_bgp_established_remote_peer object."""
+    routing_bgp_established_remote_peer.input.address = "172.16.255.2"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_established_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeerRpc()  # create object
-    prepare_routing_bgp_established_remote_peer_rpc(routing_bgp_established_remote_peer_rpc)  # add RPC input
+    routing_bgp_established_remote_peer = xr_snmp_test_trap_act.RoutingBgpEstablishedRemotePeer()  # create object
+    prepare_routing_bgp_established_remote_peer(routing_bgp_established_remote_peer)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_bgp_established_remote_peer_rpc)
+    executor.execute_rpc(provider, routing_bgp_established_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-504-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-504-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_state_change_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeerRpc()  # create object
+    routing_bgp_state_change_remote_peer = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeer()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_bgp_state_change_remote_peer_rpc)
+    executor.execute_rpc(provider, routing_bgp_state_change_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-506-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-506-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_bgp_state_change_remote_peer_rpc(routing_bgp_state_change_remote_peer_rpc):
-    """Add RPC input data to routing_bgp_state_change_remote_peer_rpc object."""
-    routing_bgp_state_change_remote_peer_rpc.input.address = "172.16.255.2"
+def prepare_routing_bgp_state_change_remote_peer(routing_bgp_state_change_remote_peer):
+    """Add RPC input data to routing_bgp_state_change_remote_peer object."""
+    routing_bgp_state_change_remote_peer.input.address = "172.16.255.2"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_bgp_state_change_remote_peer_rpc = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeerRpc()  # create object
-    prepare_routing_bgp_state_change_remote_peer_rpc(routing_bgp_state_change_remote_peer_rpc)  # add RPC input
+    routing_bgp_state_change_remote_peer = xr_snmp_test_trap_act.RoutingBgpStateChangeRemotePeer()  # create object
+    prepare_routing_bgp_state_change_remote_peer(routing_bgp_state_change_remote_peer)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_bgp_state_change_remote_peer_rpc)
+    executor.execute_rpc(provider, routing_bgp_state_change_remote_peer)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-510-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-510-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_ospf_neighbor_state_change_rpc = xr_snmp_test_trap_act.RoutingOspfNeighborStateChangeRpc()  # create object
+    routing_ospf_neighbor_state_change = xr_snmp_test_trap_act.RoutingOspfNeighborStateChange()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_ospf_neighbor_state_change_rpc)
+    executor.execute_rpc(provider, routing_ospf_neighbor_state_change)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-512-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-512-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc):
-    """Add RPC input data to routing_ospf_neighbor_state_change_rpc object."""
-    routing_ospf_neighbor_state_change_rpc.input.address = "172.16.0.1"
+def prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change):
+    """Add RPC input data to routing_ospf_neighbor_state_change object."""
+    routing_ospf_neighbor_state_change.input.address = "172.16.0.1"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_ospf_neighbor_state_change_rpc = xr_snmp_test_trap_act.RoutingOspfNeighborStateChangeRpc()  # create object
-    prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc)  # add RPC input
+    routing_ospf_neighbor_state_change = xr_snmp_test_trap_act.RoutingOspfNeighborStateChange()  # create object
+    prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_ospf_neighbor_state_change_rpc)
+    executor.execute_rpc(provider, routing_ospf_neighbor_state_change)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-514-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-514-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc):
-    """Add RPC input data to routing_ospf_neighbor_state_change_rpc object."""
+def prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change):
+    """Add RPC input data to routing_ospf_neighbor_state_change object."""
     # interfaces having IP addresses
-    routing_ospf_neighbor_state_change_rpc.input.ifindex = 0
+    routing_ospf_neighbor_state_change.input.ifindex = 0
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_ospf_neighbor_state_change_rpc = xr_snmp_test_trap_act.RoutingOspfNeighborStateChangeRpc()  # create object
-    prepare_routing_ospf_neighbor_state_change_rpc(routing_ospf_neighbor_state_change_rpc)  # add RPC input
+    routing_ospf_neighbor_state_change = xr_snmp_test_trap_act.RoutingOspfNeighborStateChange()  # create object
+    prepare_routing_ospf_neighbor_state_change(routing_ospf_neighbor_state_change)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_ospf_neighbor_state_change_rpc)
+    executor.execute_rpc(provider, routing_ospf_neighbor_state_change)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-520-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-520-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_ldp_session_down_rpc = xr_snmp_test_trap_act.RoutingMplsLdpSessionDownRpc()  # create object
+    routing_mpls_ldp_session_down = xr_snmp_test_trap_act.RoutingMplsLdpSessionDown()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_ldp_session_down_rpc)
+    executor.execute_rpc(provider, routing_mpls_ldp_session_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-522-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-522-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_ldp_session_down_rpc(routing_mpls_ldp_session_down_rpc):
-    """Add RPC input data to routing_mpls_ldp_session_down_rpc object."""
-    routing_mpls_ldp_session_down_rpc.input.entity_id = "172.16.255.1.0.0"
-    routing_mpls_ldp_session_down_rpc.input.entity_index = 2886795010
-    routing_mpls_ldp_session_down_rpc.input.peer_id = "172.16.255.2.0.0"
+def prepare_routing_mpls_ldp_session_down(routing_mpls_ldp_session_down):
+    """Add RPC input data to routing_mpls_ldp_session_down object."""
+    routing_mpls_ldp_session_down.input.entity_id = "172.16.255.1.0.0"
+    routing_mpls_ldp_session_down.input.entity_index = 2886795010
+    routing_mpls_ldp_session_down.input.peer_id = "172.16.255.2.0.0"
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_ldp_session_down_rpc = xr_snmp_test_trap_act.RoutingMplsLdpSessionDownRpc()  # create object
-    prepare_routing_mpls_ldp_session_down_rpc(routing_mpls_ldp_session_down_rpc)  # add RPC input
+    routing_mpls_ldp_session_down = xr_snmp_test_trap_act.RoutingMplsLdpSessionDown()  # create object
+    prepare_routing_mpls_ldp_session_down(routing_mpls_ldp_session_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_ldp_session_down_rpc)
+    executor.execute_rpc(provider, routing_mpls_ldp_session_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-530-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-530-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_routed_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReRoutedRpc()  # create object
+    routing_mpls_tunnel_re_routed = xr_snmp_test_trap_act.RoutingMplsTunnelReRouted()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_re_routed_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_re_routed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-532-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-532-ydk.py
@@ -38,12 +38,12 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_re_routed_rpc(routing_mpls_tunnel_re_routed_rpc):
-    """Add RPC input data to routing_mpls_tunnel_re_routed_rpc object."""
-    routing_mpls_tunnel_re_routed_rpc.input.destination = "172.16.255.2"
-    routing_mpls_tunnel_re_routed_rpc.input.index = 1
-    routing_mpls_tunnel_re_routed_rpc.input.instance = 0
-    routing_mpls_tunnel_re_routed_rpc.input.source = "172.16.255.1"
+def prepare_routing_mpls_tunnel_re_routed(routing_mpls_tunnel_re_routed):
+    """Add RPC input data to routing_mpls_tunnel_re_routed object."""
+    routing_mpls_tunnel_re_routed.input.destination = "172.16.255.2"
+    routing_mpls_tunnel_re_routed.input.index = 1
+    routing_mpls_tunnel_re_routed.input.instance = 0
+    routing_mpls_tunnel_re_routed.input.source = "172.16.255.1"
 
 
 if __name__ == "__main__":
@@ -75,11 +75,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_routed_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReRoutedRpc()  # create object
-    prepare_routing_mpls_tunnel_re_routed_rpc(routing_mpls_tunnel_re_routed_rpc)  # add RPC input
+    routing_mpls_tunnel_re_routed = xr_snmp_test_trap_act.RoutingMplsTunnelReRouted()  # create object
+    prepare_routing_mpls_tunnel_re_routed(routing_mpls_tunnel_re_routed)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_re_routed_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_re_routed)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-540-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-540-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_optimized_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimizedRpc()  # create object
+    routing_mpls_tunnel_re_optimized = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimized()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-542-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-542-ydk.py
@@ -38,12 +38,12 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_re_optimized_rpc(routing_mpls_tunnel_re_optimized_rpc):
-    """Add RPC input data to routing_mpls_tunnel_re_optimized_rpc object."""
-    routing_mpls_tunnel_re_optimized_rpc.input.destination = "172.16.255.2"
-    routing_mpls_tunnel_re_optimized_rpc.input.index = 1
-    routing_mpls_tunnel_re_optimized_rpc.input.instance = 0
-    routing_mpls_tunnel_re_optimized_rpc.input.source = "172.16.255.1"
+def prepare_routing_mpls_tunnel_re_optimized(routing_mpls_tunnel_re_optimized):
+    """Add RPC input data to routing_mpls_tunnel_re_optimized object."""
+    routing_mpls_tunnel_re_optimized.input.destination = "172.16.255.2"
+    routing_mpls_tunnel_re_optimized.input.index = 1
+    routing_mpls_tunnel_re_optimized.input.instance = 0
+    routing_mpls_tunnel_re_optimized.input.source = "172.16.255.1"
 
 
 if __name__ == "__main__":
@@ -75,11 +75,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_re_optimized_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimizedRpc()  # create object
-    prepare_routing_mpls_tunnel_re_optimized_rpc(routing_mpls_tunnel_re_optimized_rpc)  # add RPC input
+    routing_mpls_tunnel_re_optimized = xr_snmp_test_trap_act.RoutingMplsTunnelReOptimized()  # create object
+    prepare_routing_mpls_tunnel_re_optimized(routing_mpls_tunnel_re_optimized)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_re_optimized)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-550-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-550-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_down_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelDownRpc()  # create object
+    routing_mpls_tunnel_down = xr_snmp_test_trap_act.RoutingMplsTunnelDown()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_down_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-552-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-552-ydk.py
@@ -38,12 +38,12 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_snmp_test_trap_act \
 import logging
 
 
-def prepare_routing_mpls_tunnel_down_rpc(routing_mpls_tunnel_down_rpc):
-    """Add RPC input data to routing_mpls_tunnel_down_rpc object."""
-    routing_mpls_tunnel_down_rpc.input.destination = "172.16.255.2"
-    routing_mpls_tunnel_down_rpc.input.index = 1
-    routing_mpls_tunnel_down_rpc.input.instance = 0
-    routing_mpls_tunnel_down_rpc.input.source = "172.16.255.1"
+def prepare_routing_mpls_tunnel_down(routing_mpls_tunnel_down):
+    """Add RPC input data to routing_mpls_tunnel_down object."""
+    routing_mpls_tunnel_down.input.destination = "172.16.255.2"
+    routing_mpls_tunnel_down.input.index = 1
+    routing_mpls_tunnel_down.input.instance = 0
+    routing_mpls_tunnel_down.input.source = "172.16.255.1"
 
 
 if __name__ == "__main__":
@@ -75,11 +75,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    routing_mpls_tunnel_down_rpc = xr_snmp_test_trap_act.RoutingMplsTunnelDownRpc()  # create object
-    prepare_routing_mpls_tunnel_down_rpc(routing_mpls_tunnel_down_rpc)  # add RPC input
+    routing_mpls_tunnel_down = xr_snmp_test_trap_act.RoutingMplsTunnelDown()  # create object
+    prepare_routing_mpls_tunnel_down(routing_mpls_tunnel_down)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, routing_mpls_tunnel_down_rpc)
+    executor.execute_rpc(provider, routing_mpls_tunnel_down)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-900-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-snmp-test-trap-act/nc-execute-xr-snmp-test-trap-act-900-ydk.py
@@ -67,10 +67,10 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    all_rpc = xr_snmp_test_trap_act.AllRpc()  # create object
+    all = xr_snmp_test_trap_act.All()  # create object
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, all_rpc)
+    executor.execute_rpc(provider, all)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-10-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-10-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.cisco_ios_xr import Cisco_IOS_XR_syslog_act \
 import logging
 
 
-def prepare_logmsg_rpc(logmsg_rpc):
-    """Add RPC input data to logmsg_rpc object."""
+def prepare_logmsg(logmsg):
+    """Add RPC input data to logmsg object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    logmsg_rpc = xr_syslog_act.LogmsgRpc()  # create object
-    prepare_logmsg_rpc(logmsg_rpc)  # add RPC input
+    logmsg = xr_syslog_act.Logmsg()  # create object
+    prepare_logmsg(logmsg)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, logmsg_rpc)
+    # executor.execute_rpc(provider, logmsg)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-20-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-20-ydk.py
@@ -39,10 +39,10 @@ from ydk.models.ietf import ietf_syslog_types
 import logging
 
 
-def prepare_logmsg_rpc(logmsg_rpc):
-    """Add RPC input data to logmsg_rpc object."""
-    logmsg_rpc.input.message = "A custom informational message"
-    logmsg_rpc.input.severity = ietf_syslog_types.Severity.info
+def prepare_logmsg(logmsg):
+    """Add RPC input data to logmsg object."""
+    logmsg.input.message = "A custom informational message"
+    logmsg.input.severity = ietf_syslog_types.Severity.info
 
 if __name__ == "__main__":
     """Execute main program."""
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    logmsg_rpc = xr_syslog_act.LogmsgRpc()  # create object
-    prepare_logmsg_rpc(logmsg_rpc)  # add RPC input
+    logmsg = xr_syslog_act.Logmsg()  # create object
+    prepare_logmsg(logmsg)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, logmsg_rpc)
+    executor.execute_rpc(provider, logmsg)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-22-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-22-ydk.py
@@ -39,10 +39,10 @@ from ydk.models.ietf import ietf_syslog_types
 import logging
 
 
-def prepare_logmsg_rpc(logmsg_rpc):
-    """Add RPC input data to logmsg_rpc object."""
-    logmsg_rpc.input.message = "A custom warning message"
-    logmsg_rpc.input.severity = ietf_syslog_types.Severity.warning
+def prepare_logmsg(logmsg):
+    """Add RPC input data to logmsg object."""
+    logmsg.input.message = "A custom warning message"
+    logmsg.input.severity = ietf_syslog_types.Severity.warning
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    logmsg_rpc = xr_syslog_act.LogmsgRpc()  # create object
-    prepare_logmsg_rpc(logmsg_rpc)  # add RPC input
+    logmsg = xr_syslog_act.Logmsg()  # create object
+    prepare_logmsg(logmsg)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, logmsg_rpc)
+    executor.execute_rpc(provider, logmsg)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-24-ydk.py
+++ b/samples/basic/executor/models/cisco-ios-xr/Cisco-IOS-XR-syslog-act/nc-execute-xr-syslog-act-24-ydk.py
@@ -39,10 +39,10 @@ from ydk.models.ietf import ietf_syslog_types
 import logging
 
 
-def prepare_logmsg_rpc(logmsg_rpc):
-    """Add RPC input data to logmsg_rpc object."""
-    logmsg_rpc.input.message = "A custom critical message"
-    logmsg_rpc.input.severity = ietf_syslog_types.Severity.critical
+def prepare_logmsg(logmsg):
+    """Add RPC input data to logmsg object."""
+    logmsg.input.message = "A custom critical message"
+    logmsg.input.severity = ietf_syslog_types.Severity.critical
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    logmsg_rpc = xr_syslog_act.LogmsgRpc()  # create object
-    prepare_logmsg_rpc(logmsg_rpc)  # add RPC input
+    logmsg = xr_syslog_act.Logmsg()  # create object
+    prepare_logmsg(logmsg)  # add RPC input
 
     # execute RPC on NETCONF device
-    executor.execute_rpc(provider, logmsg_rpc)
+    executor.execute_rpc(provider, logmsg)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-10-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-10-ydk.py
@@ -38,8 +38,8 @@ from ydk.models.ietf import ietf_netconf_monitoring \
 import logging
 
 
-def prepare_get_schema_rpc(get_schema_rpc):
-    """Add RPC input data to get_schema_rpc object."""
+def prepare_get_schema(get_schema):
+    """Add RPC input data to get_schema object."""
     pass
 
 
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    get_schema_rpc = ietf_netconf_monitoring.GetSchemaRpc()  # create object
-    prepare_get_schema_rpc(get_schema_rpc)  # add RPC input
+    get_schema = ietf_netconf_monitoring.GetSchema()  # create object
+    prepare_get_schema(get_schema)  # add RPC input
 
     # execute RPC on NETCONF device
-    # executor.execute_rpc(provider, get_schema_rpc)
+    # executor.execute_rpc(provider, get_schema)
 
     exit()
 # End of script

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-20-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-20-ydk.py
@@ -38,9 +38,9 @@ from ydk.models.ietf import ietf_netconf_monitoring \
 import logging
 
 
-def prepare_get_schema_rpc(get_schema_rpc):
-    """Add RPC input data to get_schema_rpc object."""
-    get_schema_rpc.input.identifier = "openconfig-bgp"
+def prepare_get_schema(get_schema):
+    """Add RPC input data to get_schema object."""
+    get_schema.input.identifier = "openconfig-bgp"
 
 
 if __name__ == "__main__":
@@ -72,11 +72,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    get_schema_rpc = ietf_netconf_monitoring.GetSchemaRpc()  # create object
-    prepare_get_schema_rpc(get_schema_rpc)  # add RPC input
+    get_schema = ietf_netconf_monitoring.GetSchema()  # create object
+    prepare_get_schema(get_schema)  # add RPC input
 
     # execute RPC on NETCONF device
-    print(executor.execute_rpc(provider, get_schema_rpc))
+    print(executor.execute_rpc(provider, get_schema))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-22-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-22-ydk.py
@@ -38,10 +38,10 @@ from ydk.models.ietf import ietf_netconf_monitoring \
 import logging
 
 
-def prepare_get_schema_rpc(get_schema_rpc):
-    """Add RPC input data to get_schema_rpc object."""
-    get_schema_rpc.input.identifier = "openconfig-interfaces"
-    get_schema_rpc.input.version = "2015-11-20"
+def prepare_get_schema(get_schema):
+    """Add RPC input data to get_schema object."""
+    get_schema.input.identifier = "openconfig-interfaces"
+    get_schema.input.version = "2015-11-20"
 
 
 if __name__ == "__main__":
@@ -73,11 +73,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    get_schema_rpc = ietf_netconf_monitoring.GetSchemaRpc()  # create object
-    prepare_get_schema_rpc(get_schema_rpc)  # add RPC input
+    get_schema = ietf_netconf_monitoring.GetSchema()  # create object
+    prepare_get_schema(get_schema)  # add RPC input
 
     # execute RPC on NETCONF device
-    print(executor.execute_rpc(provider, get_schema_rpc))
+    print(executor.execute_rpc(provider, get_schema))
 
     exit()
 # End of script

--- a/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-24-ydk.py
+++ b/samples/basic/executor/models/ietf/ietf-netconf-monitoring/nc-execute-ietf-netconf-monitoring-24-ydk.py
@@ -38,11 +38,11 @@ from ydk.models.ietf import ietf_netconf_monitoring \
 import logging
 
 
-def prepare_get_schema_rpc(get_schema_rpc):
-    """Add RPC input data to get_schema_rpc object."""
-    get_schema_rpc.input.identifier = "openconfig-mpls"
-    get_schema_rpc.input.version = "2015-11-05"
-    get_schema_rpc.input.format = ietf_netconf_monitoring.Yang()
+def prepare_get_schema(get_schema):
+    """Add RPC input data to get_schema object."""
+    get_schema.input.identifier = "openconfig-mpls"
+    get_schema.input.version = "2015-11-05"
+    get_schema.input.format = ietf_netconf_monitoring.Yang()
 
 
 if __name__ == "__main__":
@@ -74,11 +74,11 @@ if __name__ == "__main__":
     # create executor service
     executor = ExecutorService()
 
-    get_schema_rpc = ietf_netconf_monitoring.GetSchemaRpc()  # create object
-    prepare_get_schema_rpc(get_schema_rpc)  # add RPC input
+    get_schema = ietf_netconf_monitoring.GetSchema()  # create object
+    prepare_get_schema(get_schema)  # add RPC input
 
     # execute RPC on NETCONF device
-    print(executor.execute_rpc(provider, get_schema_rpc))
+    print(executor.execute_rpc(provider, get_schema))
 
     exit()
 # End of script


### PR DESCRIPTION
Makes sample apps compatible with the changes introduced to RPC classes and the executor service in YDK 0.6.0.  Backward compatibility details can be seen at:
http://ydk.cisco.com/py/docs/guides/backward_compatibility.html
