### PR TITLE
Fix XE interface GigEth initialization

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-34-ydk.py
@@ -38,7 +38,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv4 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = "2"
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/cd-encode-xe-native-interface-36-ydk.py
@@ -38,7 +38,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv6 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = "2"
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv4 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = 2
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-36-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv6 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = 2
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-34-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv4 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = 2
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192

--- a/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.py
+++ b/samples/basic/netconf/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-edit-config-xe-native-interface-36-ydk.py
@@ -41,7 +41,7 @@ import logging
 def config_native(native):
     """Add config data to native object."""
     # configure IPv6 interface
-    gigabitethernet = native.interface.Gigabitethernet()
+    gigabitethernet = native.interface.GigabitEthernet()
     gigabitethernet.name = 2
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192


### PR DESCRIPTION
Sample apps were following capitalization in YDK 0.6.0 and earlier.
Starting in YDK 0.6.1, class capitalization follows more closely the
data model.  These changes make the sample apps compatible with the
latter notation.