### PR TITLE
Fix XE OSPF stub configuration

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.py
@@ -65,10 +65,11 @@ def config_native(native):
     # OSPF stub Area
     area = ospf.Area()
     area.id = 1
-    stub = area.Stub()
+    area.stub = area.Stub()
     ospf.area.append(area)
 
     native.router.ospf.append(ospf)
+
 
 if __name__ == "__main__":
     """Execute main program."""

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.py
@@ -72,6 +72,7 @@ def config_native(native):
 
     native.router.ospf.append(ospf)
 
+
 if __name__ == "__main__":
     """Execute main program."""
     parser = ArgumentParser()


### PR DESCRIPTION
Previously, stub node was created, but not properly associated with root
entity.