### PR TITLE
 Update AF references in OC BGP samples

### DIFF
--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-40-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,16 +27,16 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-41-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,16 +27,16 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-42-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,21 +27,21 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY2</export-policy>
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-43-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,21 +27,21 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY2</export-policy>
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-44-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,7 +27,7 @@
       <peer-group-name>EBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY1</export-policy>
@@ -35,14 +35,14 @@
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65002</peer-as>
         <peer-group-name>EBGP</peer-group-name>
+        <peer-as>65002</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.py
@@ -41,8 +41,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -53,8 +53,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-bgp/cd-encode-oc-bgp-45-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,7 +27,7 @@
       <peer-group-name>EBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY1</export-policy>
@@ -35,14 +35,14 @@
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65002</peer-as>
         <peer-group-name>EBGP</peer-group-name>
+        <peer-as>65002</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-40-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,16 +27,16 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     peer_group.afi_safis.afi_safi.append(afi_safi)
     bgp.peer_groups.peer_group.append(peer_group)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-41-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,16 +27,16 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-42-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,21 +27,21 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY2</export-policy>
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65001
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.export_policy.append("POLICY2")
     peer_group.afi_safis.afi_safi.append(afi_safi)

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-43-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,21 +27,21 @@
       <peer-group-name>IBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY2</export-policy>
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65001</peer-as>
         <peer-group-name>IBGP</peer-group-name>
+        <peer-as>65001</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv4Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv4Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV4UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV4UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-44-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,7 +27,7 @@
       <peer-group-name>EBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY1</export-policy>
@@ -35,14 +35,14 @@
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV4-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV4_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65002</peer-as>
         <peer-group-name>EBGP</peer-group-name>
+        <peer-as>65002</peer-as>
       </config>
       <transport>
         <config>

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.py
@@ -44,8 +44,8 @@ def config_bgp(bgp):
     # global configuration
     bgp.global_.config.as_ = 65001
     afi_safi = bgp.global_.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     bgp.global_.afi_safis.afi_safi.append(afi_safi)
 
@@ -56,8 +56,8 @@ def config_bgp(bgp):
     peer_group.config.peer_as = 65002
     peer_group.transport.config.local_address = "Loopback0"
     afi_safi = peer_group.afi_safis.AfiSafi()
-    afi_safi.afi_safi_name = oc_bgp_types.Ipv6Unicast()
-    afi_safi.config.afi_safi_name = oc_bgp_types.Ipv6Unicast()
+    afi_safi.afi_safi_name = oc_bgp_types.IPV6UNICAST()
+    afi_safi.config.afi_safi_name = oc_bgp_types.IPV6UNICAST()
     afi_safi.config.enabled = True
     afi_safi.apply_policy.config.import_policy.append("POLICY3")
     afi_safi.apply_policy.config.export_policy.append("POLICY1")

--- a/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.xml
+++ b/samples/basic/crud/models/openconfig/openconfig-bgp/nc-create-oc-bgp-45-ydk.xml
@@ -2,10 +2,10 @@
   <global>
     <afi-safis>
       <afi-safi>
-        <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+        <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         <config>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
           <enabled>true</enabled>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
         </config>
       </afi-safi>
     </afi-safis>
@@ -27,7 +27,7 @@
       <peer-group-name>EBGP</peer-group-name>
       <afi-safis>
         <afi-safi>
-          <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
+          <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           <apply-policy>
             <config>
               <export-policy>POLICY1</export-policy>
@@ -35,14 +35,14 @@
             </config>
           </apply-policy>
           <config>
-            <afi-safi-name xmlns:idx="http://openconfig.net/yang/bgp-types">idx:IPV6-UNICAST</afi-safi-name>
             <enabled>true</enabled>
+            <afi-safi-name xmlns:oc-bgp-types="http://openconfig.net/yang/bgp-types">oc-bgp-types:IPV6_UNICAST</afi-safi-name>
           </config>
         </afi-safi>
       </afi-safis>
       <config>
-        <peer-as>65002</peer-as>
         <peer-group-name>EBGP</peer-group-name>
+        <peer-as>65002</peer-as>
       </config>
       <transport>
         <config>


### PR DESCRIPTION
Makes address-family references compliant with types defined in
openconfig-bgp-types version 2.1.1.