### PR TITLE
Add sample apps for MPLS IP TTL propagation

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-mpls-lsd-cfg.
+
+usage: nc-create-xr-mpls-lsd-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_mpls_lsd_cfg \
+    as xr_mpls_lsd_cfg
+import logging
+
+
+def config_mpls_lsd(mpls_lsd):
+    """Add config data to mpls_lsd object."""
+    # To disable MPLS IP TTL propagate:
+    # "all" disables for all MPLS packets.
+    # forward disables for only forwarded MPLS packets.
+    # local disables for only locally generated MPLS packets.
+    mpls_lsd.mpls_ip_ttl_propagate_disable = xr_mpls_lsd_cfg.MplsIpTtlPropagateDisable.all
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls_lsd = xr_mpls_lsd_cfg.MplsLsd()  # create object
+    config_mpls_lsd(mpls_lsd)  # add object configuration
+
+    # create configuration on NETCONF device
+    crud.create(provider, mpls_lsd)
+
+    exit()
+# End of script

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.txt
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.txt
@@ -1,0 +1,2 @@
+mpls ip-ttl-propagate disable
+end

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-create-xr-mpls-lsd-cfg-20-ydk.xml
@@ -1,0 +1,3 @@
+<mpls-lsd xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-lsd-cfg" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+  <mpls-ip-ttl-propagate-disable>all</mpls-ip-ttl-propagate-disable>
+</mpls-lsd>

--- a/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-delete-xr-mpls-lsd-cfg-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xr/Cisco-IOS-XR-mpls-lsd-cfg/nc-delete-xr-mpls-lsd-cfg-20-ydk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-mpls-lsd-cfg.
+
+usage: nc-delete-xr-mpls-lsd-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_mpls_lsd_cfg \
+    as xr_mpls_lsd_cfg
+import logging
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    mpls_lsd = xr_mpls_lsd_cfg.MplsLsd()  # create object
+
+    # delete configuration on NETCONF device
+    crud.delete(provider, mpls_lsd)
+
+    exit()
+# End of script


### PR DESCRIPTION
Introduces two custom apps to configure MPLS IP TTL propagation:
nc-create-xr-mpls-lsd-cfg-20-ydk.py - disable for all packets
nc-delete-xr-mpls-lsd-cfg-20-ydk.py - delete all MPLS LSD config