### PR TITLE
Update nc-create-xe-native-interface-34-ydk.py

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/interface/nc-create-xe-native-interface-34-ydk.py
@@ -42,7 +42,7 @@ def config_native(native):
     """Add config data to native object."""
     # configure IPv4 interface
     gigabitethernet = native.interface.GigabitEthernet()
-    gigabitethernet.name = 2
+    gigabitethernet.name = "2"
     gigabitethernet.description = "CONNECTS TO R1 (gigabitethernet3)"
     gigabitethernet.mtu = 9192
     gigabitethernet.ip.address.primary.address = "172.16.1.0"


### PR DESCRIPTION
Changing interface name from int to string. Python hits the following error otherwise:
```
2019-01-22 16:29:32,524 - ydk - INFO - Path where models are to be downloaded: /home/cisco/.ydk/csr1kv1_830
2019-01-22 16:29:32,532 - ydk - INFO - Connected to csr1kv1 on port 830 using ssh with timeout of -1
2019-01-22 16:29:32,924 - ydk.types.Entity - ERROR - Invalid value 2 for 'name'. Got type: 'int'. Expected types: 'str'
Traceback (most recent call last):
  File "nc-edit-config-xe-native-interface-34-ydk.py", line 84, in <module>
    config_native(native)  # add object configuration
  File "nc-edit-config-xe-native-interface-34-ydk.py", line 45, in config_native
    gigabitethernet.name = 2
  File "/home/cisco/.local/lib/python2.7/site-packages/ydk/models/cisco_ios_xe/Cisco_IOS_XE_native.py", line 321563, in __setattr__
    self._perform_setattr(Native.Interface.GigabitEthernet, [u'name', u'media_type', u'port_type', u'description', u'mac_address', u'shutdown', u'keepalive', u'if_state', u'delay', u'load_interval', u'max_reserved_bandwidth', u'mtu', u'service_insertion', 'channel_protocol', 'duplex', 'cisco_ios_xe_ethernet_macsec', u'cisco_ios_xe_switch_macsec', 'nat66'], name, value)
  File "/home/cisco/.local/lib/python2.7/site-packages/ydk/types/py_types.py", line 342, in _perform_setattr
    _validate_value(self._leafs[name], name, value, self.logger)
  File "/home/cisco/.local/lib/python2.7/site-packages/ydk/types/py_types.py", line 706, in _validate_value
    raise _YModelError(err_msg)
ydk.errors.YModelError: Invalid value 2 for 'name'. Got type: 'int'. Expected types: 'str'
2019-01-22 16:29:32,974 - ydk - INFO - Disconnected from device
```

after changing it to string it works:

```
2019-01-22 16:31:11,172 - ydk - INFO - =============Generating payload to send to device=============
2019-01-22 16:31:11,172 - ydk - INFO -
<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><edit-config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <target>
    <running/>
  </target>
  <config><native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
  <interface>
    <GigabitEthernet>
      <name>2</name>
      <description>CONNECTS TO R1 (gigabitethernet3)</description>
      <load-interval>30</load-interval>
      <mtu>9192</mtu>
      <ip>
        <address>
          <primary>
            <address>172.16.1.0</address>
            <mask>255.255.255.254</mask>
          </primary>
        </address>
      </ip>
    </GigabitEthernet>
  </interface>
</native>
</config>
</edit-config>
</rpc>
2019-01-22 16:31:11,172 - ydk - INFO -

2019-01-22 16:31:11,238 - ydk - INFO - =============Reply payload received from device=============
2019-01-22 16:31:11,238 - ydk - INFO -
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="2">
  <ok/>
</rpc-reply>
```