### PR TITLE
Update nc-create-xe-native-vrf-20-ydk.py

### DIFF
--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/vrf/nc-create-xe-native-vrf-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/vrf/nc-create-xe-native-vrf-20-ydk.py
@@ -49,7 +49,7 @@ def config_native(native):
     # Route Target Creation
     export = ipv4.route_target.Export()
     export.asn_ip = "65000:1"
-    import_ = ipv4.route_target.Import_()
+    import_ = ipv4.route_target.Import()
     import_.asn_ip = "65000:1"
 
     ipv4.route_target.export.append(export)


### PR DESCRIPTION
fixing typo which causes following error
```
2019-01-22 17:37:50,446 - ydk - INFO - Connected to csr1kv1 on port 830 using ssh with timeout of -1
Traceback (most recent call last):
  File "nc-create-xe-native-vrf-22-ydk.py", line 93, in <module>
    config_native(native)  # add object configuration
  File "nc-create-xe-native-vrf-22-ydk.py", line 52, in config_native
    import_ = ipv6.route_target.Import_()
AttributeError: 'RouteTarget' object has no attribute 'Import_'
2019-01-22 17:37:50,758 - ydk - INFO - Disconnected from device
```