### PR TITLE
Add MPLS+SDN+NFV WC 2018 OpenConfig demo

### DIFF
--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/README.md
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/README.md
@@ -1,0 +1,146 @@
+# Getting Started with OpenConfig
+This testbed demonstrates a basic BGP peering deployment using 
+OpenConfig data models.  It uses two ASBRs (`asbr1` and `asbr2`) and 
+a Linux host acting as a controller where the automation scripts 
+are executed.  The controller uses the following open source tools:
+
+- Configuration management:  YANG development kit (YDK)
+- Streaming telemetry: Pipeline and Kafka
+
+Configuration changes are implemented in Python with YDK using the 
+Openconfig interface and BGP models.  Operational validations are 
+implemented in Python using a simple Kafka consumer that monitors 
+interface and BGP session state using the respective OpenConfig models.
+
+## Accessing Testbed Devices
+The two ASBRs (`asbr1` and `asbr2`) and the controller share a common
+management network.  They are reachable via ssh using the following
+addresses:
+- asbr1 - 198.18.1.11
+- asbr2 - 198.18.1.12
+- controller - 198.18.1.127
+All devices use the same username/password credentials (admin/admin).
+
+## Recommended Demo Execution
+Deployment and withdrawal of peers is acomplished with two dedicated
+scripts that take as input a peer configuration file in JSON format.
+The structure of the peer configuration is arbitrary and is not based
+on a specific data model. Both the deployment and withdrawal scripts 
+are idempotent.
+
+These are the contents of the peer configuration file:
+
+```
+admin@controller:~$ cd demo
+admin@controller:demo$ cat peers.json 
+{
+  "asbr": {
+    "name": "asbr1",
+    "address": "198.18.1.11",
+    "as": 65001
+  },
+  "peers": [{
+    "address": "192.168.0.2",
+    "as": 65002,
+    "group": "EBGP",
+    "interface": {
+      "name": "GigabitEthernet0/0/0/0",
+      "description": "Peering with AS65002",
+      "address": "192.168.0.1",
+      "netmask": 24
+    }
+  }]
+}
+admin@controller:demo$ 
+```
+
+The configuration file defines one peer for `asbr1`.  The peering details 
+include the desired BGP and interface configuration. Note the peering 
+device has been partially pre-configured with BGP global and peer group 
+configuration, in addition to a basic route policy and appropriate 
+telemetry sensors to stream BGP and interface state.  
+
+Here is a sample execution of the deployment script using the peer
+configuration file as input:
+
+```
+admin@controller:demo$ ./deploy_peers.py peers.json 
+02:50:29.978416: Loading peer config ................................. [ OK ]
+02:50:29.979221: Initializing connections ............................ [ OK ]
+02:50:31.431766: Configure peer interface GigabitEthernet0/0/0/0 ..... [ OK ]
+02:50:36.080111: Configure BGP peer 192.168.0.2 ...................... [ OK ]
+admin@controller:demo$ 
+```
+
+Each task is confirmed with an `OK` if it is completed successfully.  For the
+BGP and interface configuration tasks in particular, successful completion is
+only reported if the proper operational state is validated using the 
+BGP and interface state that `asbr1` streams. If validation can't be completed
+after 60 seconds, the configuration task execution reports a `FAIL` completion.
+
+Here is a sample execution of the withdrawal script using the peer 
+configuration file as input:
+
+```
+admin@controller:demo$ ./withdraw_peers.py peers.json 
+03:33:21.460814: Loading peer config ................................. [ OK ]
+03:33:21.461946: Initializing connections ............................ [ OK ]
+03:33:22.755176: Remove peer interface GigabitEthernet0/0/0/0 ........ [ OK ]
+03:33:24.362452: Remove BGP peer 192.168.0.2 ......................... [ OK ]
+admin@controller:demo$ 
+```
+
+The widthdrawal script does not make use of telemetry data for validation.
+
+## Exploring Individual Tasks
+Individual tasks can be executed with the following scripts:
+
+```
+config_bgp_peer.py
+config_peer_interface.py
+remove_bgp_peer.py
+remove_peer_interface.py
+validate_bgp_peer.py
+validate_peer_interface.py
+```
+
+These scripts take their input from command line arguments.  They do not
+make use of the peer configuration file (`peers.json`).  You can
+experiment using different inputs and executing the scripts against any
+of the two ASBRs. The file `demo-script.md` includes the invocation of 
+each script with arguments equivalent to the data in the configuration
+file (`peers.json`)
+
+# Tool Chain Configuration
+Pipeline, Kafka (including Zookeeper) run on separate docker containers:
+
+```
+admin@controller:demo$ docker ps
+CONTAINER ID        IMAGE                           COMMAND                  CREATED             STATUS              PORTS                                        NAMES
+111b9c10c0af        pipeline:1.0.0                  "/pipeline -log=/dat…"   7 weeks ago         Up 19 hours                                                      pipeline
+7f28639cfa6b        confluent/kafka:0.10.0.0-cp1    "/usr/local/bin/kafk…"   7 weeks ago         Up 19 hours         0.0.0.0:9092->9092/tcp                       kafka
+5ab7a5f9e685        confluent/zookeeper:3.4.6-cp1   "/usr/local/bin/zk-d…"   7 weeks ago         Up 19 hours         2888/tcp, 0.0.0.0:2181->2181/tcp, 3888/tcp   zookeeper
+admin@controller:demo$
+```
+
+YDK is installed directly on the controller host:
+
+```
+admin@controller:demo$ pip3 list | grep ydk
+ydk                   0.7.1                 
+ydk-models-ietf       0.1.5                 
+ydk-models-openconfig 0.1.5                 
+admin@controller:demo$ 
+```
+
+You can experiment re-configuring the collector.  The configuration file (`pipeline.conf`) can be found at:
+
+```
+admin@controller:~$ ls demo/telemetry/pipeline/pipeline.conf 
+demo/telemetry/pipeline/pipeline.conf
+admin@controller:~$ 
+```
+
+Note that you need to restart the Pipeline container for the configuration changes to take effect.
+
+Enjoy!

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/config_bgp_peer.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/config_bgp_peer.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for BGP peer.
+
+usage: config_bgp_peer.py [-h] [-v] local_as peer_address peer_as device
+
+positional arguments:
+  local_as       local autonomous system
+  peer_address   peer address
+  peer_as        peer autonomous system
+  peer_group     peer group
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import argparse
+import urllib.parse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_bgp as oc_bgp
+import logging
+
+
+def config_bgp_peer(bgp, local_as, peer_address, peer_as, peer_group):
+    """Add config data to bgp object."""
+    # configure global bgp
+    bgp.global_.config.as_ = local_as
+
+    # configure neighbor
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = peer_address
+    neighbor.config.neighbor_address = peer_address
+    neighbor.config.peer_as = peer_as
+    neighbor.config.peer_group = peer_group
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", 
+                        help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("local_as",
+                        help="local autonomous system")
+    parser.add_argument("peer_address",
+                        help="peer address")
+    parser.add_argument("peer_as",
+                        help="peer autonomous system")
+    parser.add_argument("peer_group",
+                        help="peer group")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urllib.parse.urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # BGP configuration
+    bgp = oc_bgp.Bgp()
+    config_bgp_peer(bgp, args.local_as, args.peer_address, args.peer_as, args.peer_group)
+
+    # create configuration on NETCONF device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/config_peer_interface.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/config_peer_interface.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for peer interface.
+
+usage: config_peer_interface.py [-h] [-v] name description address netmask device
+
+positional arguments:
+  name           interface name
+  description    interfaces description
+  address        interface address
+  netmask        interface network mask
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import argparse
+import urllib.parse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces as oc_interfaces
+from ydk.models.ietf import iana_if_type
+import logging
+
+
+def config_peer_interface(interfaces, name, description, address, netmask):
+    """Add config data to interfaces object."""
+    # configure interface
+    interface = interfaces.Interface()
+    interface.name = name
+    interface.config.name = name
+    interface.config.type = iana_if_type.Ethernetcsmacd()
+    interface.config.description = description
+    interface.config.enabled = True
+
+    # configure ip subinterface
+    subinterface = interface.subinterfaces.Subinterface()
+    subinterface.index = 0
+    subinterface.config.index = 0
+    address_ = subinterface.ipv4.addresses.Address()
+    address_.ip = address
+    address_.config.ip = address
+    address_.config.prefix_length = netmask
+    subinterface.ipv4.addresses.address.append(address_)
+    interface.subinterfaces.subinterface.append(subinterface)
+    interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", 
+                        help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("name",
+                        help="interface name")
+    parser.add_argument("description",
+                        help="interfaces description")
+    parser.add_argument("address",
+                        help="interface address")
+    parser.add_argument("netmask",
+                        help="interface network mask")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urllib.parse.urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # interface configuration
+    interfaces = oc_interfaces.Interfaces()
+    config_peer_interface(interfaces, args.name, args.description, args.address, args.netmask)
+
+    # create configuration on NETCONF device
+    crud.create(provider, interfaces)
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/consume_telemetry.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/consume_telemetry.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Consume streaming telemetry data from kafka bus.
+
+usage: consume_telemetry.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+
+import kafka
+import json
+import logging
+
+
+KAFKA_TOPIC = 'pipeline'
+KAFKA_BOOTSTRAP_SERVER = 'localhost:9092'
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("kafka")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+
+
+    # create kafka consumer to pipeline topic
+    kafka_consumer = kafka.KafkaConsumer(KAFKA_TOPIC,
+                                         bootstrap_servers=KAFKA_BOOTSTRAP_SERVER)
+
+    for kafka_msg in kafka_consumer:
+        print(json.dumps(json.loads(kafka_msg.value.decode('utf-8')), indent=4))
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/demo-script.md
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/demo-script.md
@@ -1,0 +1,23 @@
+# One command demo execution
+./deploy_peers.py peers.json
+
+# One command demo cleanup
+./withdraw_peers.py peers.json
+
+# Configure individual peer interface
+./config_peer_interface.py GigabitEthernet0/0/0/0 "Peering with AS65002" 192.168.0.1 24 ssh://admin:admin@198.18.1.11
+
+# Validate individual peer interface
+./validate_peer_interface.py asbr1 GigabitEthernet0/0/0/0
+
+# Configure individual BGP peer
+./config_bgp_peer.py 65001 192.168.0.2 65002 EBGP ssh://admin:admin@198.18.1.11
+
+# Validate individual BGP peer
+./validate_bgp_peer.py asbr1 192.168.0.2
+
+# Remove individual peer interface
+./remove_peer_interface.py GigabitEthernet0/0/0/0 ssh://admin:admin@198.18.1.11
+
+# Remove individual BGP peer
+./remove_bgp_peer.py 65001 192.168.0.2 ssh://admin:admin@198.18.1.11

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/deploy_peers.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/deploy_peers.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Deploy peer configuration.
+
+usage: deploy_peer.py [-h] [-v] FILE
+
+positional arguments:
+  peer_config_file_name    peer configuration file (JSON)
+
+optional arguments:
+  -h, --help               show this help message and exit
+  -v, --verbose            print debugging messages
+"""
+
+import argparse
+import kafka
+import sys
+import json
+import datetime
+import logging
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces as oc_interfaces
+from ydk.models.openconfig import openconfig_bgp as oc_bgp
+
+from config_peer_interface import config_peer_interface
+from validate_peer_interface import validate_peer_interface
+from config_bgp_peer import config_bgp_peer
+from validate_bgp_peer import validate_bgp_peer
+
+KAFKA_TOPIC = 'pipeline'
+KAFKA_BOOTSTRAP_SERVER = "localhost:9092"
+KAFKA_TIMEOUT = 30
+
+VALIDATE_TIMEOUT = 60
+
+USERNAME = PASSWORD = "admin"
+PLEN = 70  # output padding length
+PCHAR = '.'  # output padding character
+
+sys.dont_write_bytecode = True
+
+
+def load_peer_config_file(peer_config_file_name):
+    """Load peer configuration file (JSON)"""
+    with open(peer_config_file_name) as peer_config_file:
+        config = json.load(peer_config_file)
+
+    return config
+
+
+def init_connections(address):
+    """Initialize all connections"""
+    # create kafka consumer to pipeline topic
+    kafka_consumer = kafka.KafkaConsumer(KAFKA_TOPIC,
+                                         bootstrap_servers=KAFKA_BOOTSTRAP_SERVER,
+                                         consumer_timeout_ms=KAFKA_TIMEOUT*1000)
+
+    # connect to LER
+    provider = NetconfServiceProvider(address=address,
+                                      username=USERNAME,
+                                      password=PASSWORD)
+
+    # create CRUD service
+    crud = CRUDService()
+
+    return kafka_consumer, provider, crud
+
+
+def format_validate_msg(status):
+    """Format validation message in color"""
+    OK = '\033[92m OK \033[0m'
+    FAIL = '\033[91mFAIL\033[0m'
+    if status:
+        return OK
+    else:
+        return FAIL
+
+
+def deploy_peer_interface(kafka_consumer, provider, crud, asbr, peer):
+    """Configure and validate peer interface"""
+    # interface configuration
+    interfaces = oc_interfaces.Interfaces()
+    config_peer_interface(interfaces,
+                          name=peer["interface"]["name"],
+                          description=peer["interface"]["description"],
+                          address=peer["interface"]["address"],
+                          netmask=peer["interface"]["netmask"])
+
+    # create configuration on NETCONF device
+    crud.create(provider, interfaces)
+
+    return validate_peer_interface(kafka_consumer,
+                                   asbr["name"],
+                                   peer["interface"]["name"],
+                                   timeout=VALIDATE_TIMEOUT)
+
+
+def deploy_bgp_peer(kafka_consumer, provider, crud, asbr, peer):
+    """Configure and validate BGP peer"""
+    # BGP peer configuration
+    bgp = oc_bgp.Bgp()
+    config_bgp_peer(bgp,
+                    local_as=asbr["as"],
+                    peer_address=peer["address"],
+                    peer_as=peer["as"],
+                    peer_group=peer["group"])
+
+    # create configuration on NETCONF device
+    crud.create(provider, bgp)
+
+    return validate_bgp_peer(kafka_consumer,
+                             asbr["name"],
+                             peer["address"],
+                             timeout=VALIDATE_TIMEOUT)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("peer_config_file_name",
+                        help="peer configuration file (JSON)")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    print("{}: Loading peer config ".format(datetime.datetime.now().time()).ljust(PLEN, PCHAR),
+          end='', flush=True)
+    config = load_peer_config_file(args.peer_config_file_name)
+    print(" [{}]".format(format_validate_msg(True)))
+
+    print("{}: Initializing connections ".format(datetime.datetime.now().time()).ljust(PLEN, PCHAR),
+          end='', flush=True)
+    kafka_consumer, provider, crud = init_connections(config["asbr"]["address"])
+    print(" [{}]".format(format_validate_msg(True)))
+
+    # deploy peers
+    for peer in config["peers"]:
+        print("{}: Configure peer interface {} ".format(datetime.datetime.now().time(),
+                                                        peer["interface"]["name"]).ljust(PLEN, PCHAR),
+              end='', flush=True)
+        peer_interface_status = deploy_peer_interface(kafka_consumer, provider, crud,
+                                                      config["asbr"],
+                                                      peer)
+        print(" [{}]".format(format_validate_msg(peer_interface_status)))
+
+        # deploy BGP peer if peer interface deployed successfully
+        if peer_interface_status:
+            print("{}: Configure BGP peer {} ".format(datetime.datetime.now().time(),
+                                                      peer["address"]).ljust(PLEN, PCHAR),
+                  end='', flush=True)
+            bgp_peer_status = deploy_bgp_peer(kafka_consumer, provider, crud,
+                                              config["asbr"],
+                                              peer)
+            print(" [{}]".format(format_validate_msg(bgp_peer_status)))
+
+    sys.exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/peers.json
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/peers.json
@@ -1,0 +1,18 @@
+{
+  "asbr": {
+    "name": "asbr1",
+    "address": "198.18.1.11",
+    "as": 65001
+  },
+  "peers": [{
+    "address": "192.168.0.2",
+    "as": 65002,
+    "group": "EBGP",
+    "interface": {
+      "name": "GigabitEthernet0/0/0/0",
+      "description": "Peering with AS65002",
+      "address": "192.168.0.1",
+      "netmask": 24
+    }
+  }]
+}

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/remove_bgp_peer.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/remove_bgp_peer.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Remove configuration for BGP peer.
+
+usage: remove_bgp_peer.py [-h] [-v] local_as peer_address device
+
+positional arguments:
+  local_as       local autonomous system
+  peer_address   peer address
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import argparse
+import urllib.parse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_bgp as oc_bgp
+from ydk.filters import YFilter
+import logging
+
+
+def bgp_peer_remove_filter(bgp, local_as, peer_address):
+    "Define filter to remove BGP peer"
+    bgp.global_.as_ = local_as
+    neighbor = bgp.neighbors.Neighbor()
+    neighbor.neighbor_address = peer_address
+    neighbor.yfilter = YFilter.remove
+    bgp.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", 
+                        help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("local_as",
+                        help="local autonomous system")
+    parser.add_argument("peer_address",
+                        help="peer address")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urllib.parse.urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # BGP configuration filter
+    bgp = oc_bgp.Bgp()
+    bgp_peer_remove_filter(bgp, args.local_as, args.peer_address)
+
+    # update configuration on NETCONF device
+    crud.update(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/remove_peer_interface.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/remove_peer_interface.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Remove configuration for peer interface.
+
+usage: remove_peer_interface.py [-h] [-v] name device
+
+positional arguments:
+  name           interface name
+  device         NETCONF device (ssh://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import argparse
+import urllib.parse
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces as oc_interfaces
+from ydk.models.ietf import iana_if_type
+from ydk.filters import YFilter
+import logging
+
+
+def peer_interface_remove_filter(interfaces, name):
+    "Define filter to remove peer interface"
+    interface = interfaces.Interface()
+    interface.name = name
+    interface.config.name = name
+    interface.config.type = iana_if_type.Ethernetcsmacd()
+    interface.config.description = ''
+    interface.config.enabled = False
+    interface.subinterfaces.yfilter = YFilter.remove
+    interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", 
+                        help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("name",
+                        help="interface name")
+    parser.add_argument("device",
+                        help="NETCONF device (ssh://user:password@host:port)")
+    args = parser.parse_args()
+    device = urllib.parse.urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create NETCONF provider
+    provider = NetconfServiceProvider(address=device.hostname,
+                                      port=device.port,
+                                      username=device.username,
+                                      password=device.password,
+                                      protocol=device.scheme)
+    # create CRUD service
+    crud = CRUDService()
+
+    # interface configuration filter
+    interfaces = oc_interfaces.Interfaces()
+    peer_interface_remove_filter(interfaces, args.name)
+
+    # update configuration on NETCONF device
+    crud.update(provider, interfaces)
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/telemetry/pipeline/pipeline.conf
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/telemetry/pipeline/pipeline.conf
@@ -1,0 +1,439 @@
+##############################################
+# Global bits of config in the default section
+#
+[default]
+
+#
+# ID is used to identify pipeline to third parties, e.g. fluentd tag
+# and prometheus instance
+id = pipeline
+
+#
+# Prometheus setup to export metrics about the pipeline. This is where
+# prometheus will come and scrape metrics from. This configuration is
+# only pertinent if you plan to monitor the pipeline itself using
+# prometheus - and can be ignored. You can to comment out
+# metamonitoring_prometheus_resource to stop from serving metrics.  If
+# you do wish to monitor pipeline, tools/monitor/run.sh will fire
+# prometheus and grafana with some prebuilt dashboards (requires
+# docker). Point a browser at localhost:3000 as per
+# https://github.com/grafana/grafana#running
+#
+metamonitoring_prometheus_resource = /metrics
+metamonitoring_prometheus_server = :8989
+
+# fluentd setup allows pipeline to export its logs in support of
+# manageability at scale. Tag used is derived from ID
+#
+# fluentd = localhost:24224
+
+# base_path_xlation
+# This option points at a file which contains JSON base path mappings
+# of base_path. This is typically used to morph PDT to MDT paths on
+# input side where it makes sense (i.e. gpb and gpb codecs). Not
+# applied to SNMP since base path is derived from snmp spec. (JSON is
+# missing because today Telemetry header it not assumed for JSON
+# inputs. This may change in the future.
+# base_path_xlation=bpx.json
+
+#
+# Section start with a section name. The only constraint for section
+# names is that 'default' is not used. You can have as many sections
+# as you wish, as long as each section has a unique name.
+
+##############################################
+# Example of a TCP dialout (router connects to pipeline over TCP)
+#
+[testbed]
+stage = xport_input
+#
+# Module type, the type dictates the rest of the options in the section.
+# TCP can only be used as xport_iinput currently. UDP works similarly.
+#
+type = tcp
+#
+# Supported encapsulation is 'st' for streaming telemetry header. This
+# is the header used to carry streaming telemetry payload in TCP and UDP.
+#
+encap = st
+#
+# TCP option dictating which binding to listen on. Can be a host name
+# or address and port, or just port.
+#
+listen = :5432
+#
+# To enable dumping data as it is rxed, uncomment the following, and
+# run with --debug option.
+#
+# logdata = on
+#
+# It is also possible to turn on TCP keepalives. Setting keepalive to
+# 0 (default) stops pipeline from explicitly turning on
+# keepalives. Otherwise, keepalive is turned on with period.  TCP
+# Keepalives do NOT need any special explicit configuration or support
+# from the other end.
+#
+# keepalive_seconds = 0
+
+##############################################
+# Example of a gRPC dialin (pipeline connects to router over gRPC)
+# [mymdtrouter]
+# stage = xport_input
+#
+# grpc: in the role client connecting to router doing server side
+# streaming.
+#
+# type = grpc
+#
+# Encoding requested by grpc client: gpbcompact, gpbkv
+# This is only pertinent to dialin and describes the request
+# to the router - i.e. do I want compact or k/v payload
+# encoding = gpbkv
+#
+# Encapsulation pushed by client: gpb, gpbkv, gpbcompact
+# As of 6.1.1 release, we support gpb (which is a common
+# header used to carry compact and k/v gpb). In older
+# releases, it might be necessary to configure compact or k/v.
+# encap = gpb
+#
+# Server to connect to
+#
+#server = 192.168.123.2:57344
+#
+# Subscription IDs to subscribe to, as configured on the router. Set
+# is specified as a comma separated string of subscription ID names.
+#
+#subscriptions = sub1,sub2
+#
+#
+# Access control options; TLS,  username/password
+#
+# TLS enabled or not, CA cert in PEM, and server name to accept.
+#
+# tls = false
+# tls_pem = ca.pem
+# tls_servername = tlsservername
+#
+# username/password
+#
+# Public key encrypted password is specified here. The pem with RSA
+# key used to encrypt passwords is passed in as a cli argument.
+#
+# The encrypted password will be generated if pipeline is run, -pem is
+# specified, and password option is NOT included in the section. In
+# that user will be prompted for user/pass, and a new separate copy of
+# configuration will be created for convenience.
+#
+# Passphrase-less RSA key pair can be generated using ssh-keygen if
+# necessary: 'ssh-keygen -t rsa -b 4096'
+#
+# username = johndoe
+# password = eBzbEJi6dXF+a9gmII7lJdtbd9o8HCDwjJqZl2eK...
+#
+# To enable dumping data as it is rxed, uncomment the following, and
+# run with --debug option.
+#
+# logdata = on
+#
+
+# [mymdtrouter]
+# stage = xport_input
+# type = grpc
+# encoding = gpbkv
+# server = 192.168.123.2:57344
+# subscriptions = HEALTH,QOS
+# tls = true
+# tls_pem = ca.pem
+# tls_servername = tlsservername
+# username = johndoe
+# password = eBzbEJi6dXF+a9gmII7lJdtbd9o8HCDwjJqZl2eK...
+
+##############################################
+# Example of a gRPC dialout (router connects to pipeline over gRPC)
+#[gRPCDialout]
+#
+# stage = xport_input
+#
+# grpc: in the role of server with router connecting to pipeline and
+# client side streaming.
+#
+# type = grpc
+#
+# encap = gpb
+# Encapsulation pushed by client: gpb, gpbkv, gpbcompact.
+# As of 6.1.1 release, we support gpb (which is a common
+# header used to carry compact and k/v gpb), and we default
+# to gpb. In older releases, it might be necessary to configure
+# compact or k/v.
+#
+# Socket to listen on
+#
+# listen = :57500
+#
+# Access control options; TLS
+#
+# TLS enabled or not, server CA cert in PEM, and server name cert
+# issued for. (Look for CN in 'openssl x509 -noout -text -in <ca.pem>')
+#
+# tls = false
+# tls_pem = cert.pem
+# tls_key = server.key
+# tls_servername = tlsservername
+#
+# To enable dumping data as it is rxed, uncomment the following, and
+# run with --debug option.
+#
+# logdata = on
+#
+
+##############################################
+# Example of a replay input stage: used to replay telemetry archive
+#
+# [replay_archive]
+# stage = xport_input
+# type = replay
+#
+# Mandatory setting indicating file containing the archive. The archive
+# can be generated from real telemetry using an output 'tap' module
+# configured with `raw=true` instead of an `encoding=` option.
+# file = dump.bin
+#
+# The archive in the file will be replayed over and over unless the
+# number of messages required is specified and if loop is set to
+# true. This number of messages sent can be specified using the firstn
+# option. Note that if firstn exceeds the number of message in the
+# archive the stamped time will go back. (In future, a restamp option
+# may be made available.) Loop is ignored if firstn is set.
+# loop = false
+# firstn = 1000
+#
+# The delay between messages originated can be configured in micorseconds
+# using the delayusec option. Default is for a 200ms delay between replayed
+# messages
+# delayusec = 200000
+
+
+##############################################
+# Example of a kafka output stage: used to publish content to kafka
+#
+[mykafka]
+stage = xport_output
+#
+# Module type: kafka publisher is only supported in xport_output stage currently.
+#
+type = kafka
+#
+# Kafka specific key option. This is an optional setting and is
+# specific to a weird requirement of our home grown consumer on kafka
+# bus.
+#
+# key = id
+#
+# Encoding: gpb, gpbkv, json or json_events
+#
+encoding = json
+#
+# Kafka specific option. The brokers for the kafka bus
+#
+brokers = localhost:9092
+#
+# Kafka specific option. The topic to publish against.
+#
+topic = pipeline
+#
+# Optional: It is also possible to specify a dynamic derivation of
+# topic to send on. This mechanism is a text template applied to the
+# metadata of the message; currently a structure containing the Path
+# (encoding path) and Identifier (router name) fields. In future the
+# whole message body may be exposed. In the case where the template
+# fails to extract and return a string, the message will be published
+# on 'topic' above.
+#
+# The example extract encoding path:
+#
+# topic_metadata_template = topic_template_testb.txt
+#
+# The option required_acks can be used to influence whether the
+# producer waits for acknowledgments from just the local broker
+# (i.e. the broker to which the message is published), or for a
+# consensus commit from replicas. The options are "local" and "commit"
+# respectively. By default, we default to "none".
+#
+# required_acks = none
+#
+# The optional buffered channel depth used to accommodate transient
+# producer/consumer throughput.
+#
+# datachanneldepth = 1000
+#
+# To enable dumping data as it is rxed, uncomment the following, and
+# run with --debug option.
+#
+# logdata = on
+
+##############################################
+# Example of kafka input stage: used to consume content from kafka
+#
+# [kafkaconsumer]
+# type = kafka
+# key = path_and_id
+# stage = xport_input
+# brokers = kafka.example.com:9092
+# topic = consumertopic3
+#
+# Multiple clients can dynamically loadbalance consumption from different
+# partitions as long as they share the same consumer group name
+# consumergroup = mycollectors
+# encoding = json
+# logdata = on
+
+##############################################
+# Example of a tap stage; dump content to file, or at least count messages
+#
+# [inspector]
+# stage = xport_output
+#
+# Module type: tap is only supported in xport_output stage currently.
+#
+# type = tap
+#
+# File to dump decoded messages
+#
+# file = /data/dump.txt
+#
+# encoding = json
+#
+# Options: json_events | gpb, gpb_kv. If format is a binary format, or
+# not supported for input encoding in use (gpb if proto is available,
+# gpbk/v or JSON), we fall back to hex. Default is JSON
+#
+
+# raw = true
+#
+# If raw is set to true, no encoding should be specified. The outcome
+# is that raw payload is dumped on top of a streaming telemetry
+# header. The resulting archive can be replayed (i.e. reread and fed
+# to output stages) by pipeline using the 'replay' input module.
+#
+
+# The optional buffered channel depth used to accommodate transient
+# producer/consumer throughput.
+#
+datachanneldepth = 1000
+
+# If all we want to do is count frames, set countonly to true
+#
+# countonly = false
+
+##############################################
+# Example of a metrics stage; allows us to export content to a time
+# series database (influxdb or prometheus) as well as measure time
+# distribution of samples.
+#
+# [mymetrics]
+# stage = xport_output
+#
+# Module type: metrics is only supported in xport_output stage
+#
+# type = metrics
+#
+# Spec of metrics to collect in metrics.json
+#
+# file = /data/metrics.json
+#
+# The optional buffered channel depth used to accommodate transient
+# producer/consumer throughput.
+#
+# datachanneldepth = 1000
+#
+# For troubleshooting purposes, it is possible to dump the metrics to
+# a local file/s, in order to understand what is being exported from
+# persepective of pipeline metrics module.
+#
+# dump = metricsdump.txt
+#
+# What type of package we export too. Options include influx or prometheus.
+#
+# output = influx
+#
+# Config options for influx is currently
+#
+# Influx server
+# influx = http://influx.example.com:8086
+#
+# Database to populate, currently static (might be templatised in the future).
+# Expectation is that database exists and user has read/write access.
+# database = dbname
+#
+# Workers; number of different sessions set up with influx node.
+# workers = 10
+#
+
+# Config options for prometheus is currently
+#
+# Prometheus option: pushgw, address:port where to push metrics too
+#
+# pushgw = pushgw.example.com:9091
+#
+# Prometheus option: jobname provides the prometheus jobname associated
+# with all exported metrics. Default provided
+#
+# jobname = telemetry
+#
+# Prometheus option: instance provides the prometheus instance
+# associated with all exported metrics from this pipeline. Default
+# provided is to use ID (in default section)
+#
+# instance = myinstance
+#
+# Track statistics about metrics collections. This only makes sense if
+# we are metamonitoring too i.e. metamonitoring configuration. Sensor
+# collection stats are tracked if the metric specification indicates
+# "track": true for the sensor in question. For any sensor marked
+# "track" we export to prometheus statistics about the intersample
+# gap. This allows us to visualise median period, as well as 90th and
+# 99th percentile of all periods. In other words, we can plot over
+# time the period within which n (for n = 50, 90 or 99) % the next
+# sample is received.
+#
+# Max number of sensor instances tracked at one time? Not cheap
+# (e.g. we stach labels)! Must be set for any stats to be exported.
+# statsensorcount = 1000
+
+##############################################
+# Example of a grpcOut stage which allows other parties to pull
+# content from pipeline over gRPC. pipeline acts as a server and
+# server side streams all content received using the specified
+# encoding (usual matrix of input/output encoding applies)
+
+# [mygrpcout]
+# type = grpc
+# stage = xport_output
+# encoding = json
+# listen = localhost:5959
+# logdata = off
+
+##############################################
+# Example of how to apply template transformation on content pushed
+# out of any output stage (exception: metrics output). Template is
+# applied over GPB K/V input streams (others will follow if required)
+# and uses golang text templates.
+#
+# [templatetest]
+# stage = xport_output
+# type = tap
+# file = dumpfiltererd.txt
+# encoding = template
+# template = filter_test.json
+
+##############################################
+# Example of a UDP stage which allows other parties to connect
+# over UDP and produce content over the st header (same as TCP)
+
+# [udpin]
+# type = udp
+# stage = xport_input
+# listen = localhost:5958
+# encap = st
+# logdata = off
+

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/validate_bgp_peer.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/validate_bgp_peer.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Validate BGP peer operation.
+
+usage: validate_bgp_peer.py [-h] [-v] node peer_address
+
+positional arguments:
+  node           node streaming interface status
+  peer_address   peer address
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import kafka
+import json
+import time
+import logging
+
+from argparse import ArgumentParser
+
+KAFKA_TOPIC = 'pipeline'
+KAFKA_BOOTSTRAP_SERVER = 'localhost:9092'
+SESSION_STATE_ESTABLISHED = "ESTABLISHED"
+TIMEOUT = 30
+
+
+def validate_bgp_peer(kafka_consumer, node, peer_address,
+                      session_state=SESSION_STATE_ESTABLISHED,
+                      timeout=TIMEOUT):
+    """Validate BGP session state."""
+    telemetry_encoding_path = "openconfig-bgp:bgp/neighbors"
+    start_time = time.time()
+    for kafka_msg in kafka_consumer:
+        msg = json.loads(kafka_msg.value.decode('utf-8'))
+        if (msg["Telemetry"]["node_id_str"] == node and
+                msg["Telemetry"]["encoding_path"] == telemetry_encoding_path
+                and "Rows" in msg):
+            for row in msg["Rows"]:
+                if "neighbor" in row["Content"]:
+                    current_peer_address = (row["Content"]["neighbor"]
+                                               ["neighbor-address"])
+                    current_session_state = (row["Content"]["neighbor"]
+                                                ["state"]["session-state"])
+                    # return if BGP session in expected state
+                    if (current_peer_address == peer_address
+                            and current_session_state == session_state):
+                        return True
+
+        if time.time() - start_time > timeout:
+            break
+
+    return False
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("node",
+                        help="node router streaming interface status")
+    parser.add_argument("peer_address",
+                        help="peer address")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("kafka")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create kafka consumer to pipeline topic
+    kafka_consumer = kafka.KafkaConsumer(KAFKA_TOPIC,
+                                         bootstrap_servers=KAFKA_BOOTSTRAP_SERVER,
+                                         consumer_timeout_ms=TIMEOUT*1000)
+
+    print(validate_bgp_peer(kafka_consumer, args.node, args.peer_address))
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/validate_peer_interface.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/validate_peer_interface.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Validate peer interface operation.
+
+usage: validate_peer_interface.py [-h] [-v] node name
+
+positional arguments:
+  node           node streaming interface status
+  name           interface name
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+import kafka
+import json
+import time
+import logging
+
+from argparse import ArgumentParser
+
+KAFKA_TOPIC = 'pipeline'
+KAFKA_BOOTSTRAP_SERVER = 'localhost:9092'
+STATUS_UP = "UP"
+TIMEOUT = 30
+
+
+def validate_peer_interface(kafka_consumer, node, name,
+                            status=STATUS_UP,
+                            timeout=TIMEOUT):
+    """Validate interface status."""
+    telemetry_encoding_path = "openconfig-interfaces:interfaces/interface"
+    start_time = time.time()
+    for kafka_msg in kafka_consumer:
+        msg = json.loads(kafka_msg.value.decode('utf-8'))
+        if (msg["Telemetry"]["node_id_str"] == node and
+                msg["Telemetry"]["encoding_path"] == telemetry_encoding_path
+                and "Rows" in msg):
+            for row in msg["Rows"]:
+                if "state" in row["Content"]:
+                    current_name = row["Keys"]["name"]
+                    current_oper_status = (row["Content"]["state"]
+                                              ["oper-status"])
+                    current_admin_status = (row["Content"]["state"]
+                                               ["admin-status"])
+                    # return if intf in expected oper/admin status
+                    if (current_name == name
+                            and current_oper_status == status
+                            and current_admin_status == status):
+                        return True
+
+        if time.time() - start_time > timeout:
+            break
+
+    return False
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("node",
+                        help="node router streaming interface status")
+    parser.add_argument("name",
+                        help="interface name")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("kafka")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create kafka consumer to pipeline topic
+    kafka_consumer = kafka.KafkaConsumer(KAFKA_TOPIC,
+                                         bootstrap_servers=KAFKA_BOOTSTRAP_SERVER,
+                                         consumer_timeout_ms=TIMEOUT*1000)
+
+    print(validate_peer_interface(kafka_consumer, args.node, args.name))
+
+    exit()
+# End of script

--- a/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/withdraw_peers.py
+++ b/samples/intermediate/peering/bgp/mplswc18/openconfig/demo/withdraw_peers.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Withdraw peer configuration.
+
+usage: withdraw_peers.py [-h] [-v] FILE
+
+positional arguments:
+  peer_config_file_name    peer configuration file (JSON)
+
+optional arguments:
+  -h, --help               show this help message and exit
+  -v, --verbose            print debugging messages
+"""
+
+import argparse
+import sys
+import json
+import datetime
+import logging
+
+from ydk.services import CRUDService
+from ydk.providers import NetconfServiceProvider
+from ydk.models.openconfig import openconfig_interfaces as oc_interfaces
+from ydk.models.openconfig import openconfig_bgp as oc_bgp
+
+from remove_peer_interface import peer_interface_remove_filter
+from remove_bgp_peer import bgp_peer_remove_filter
+
+
+USERNAME = PASSWORD = "admin"
+PLEN = 70  # output padding length
+PCHAR = '.'  # output padding character
+
+sys.dont_write_bytecode = True
+
+
+def load_peer_config_file(peer_config_file_name):
+    """Load peer configuration file (JSON)"""
+    with open(peer_config_file_name) as peer_config_file:
+        config = json.load(peer_config_file)
+
+    return config
+
+
+def init_connections(address):
+    """Initialize all connections"""
+    # connect to LER
+    provider = NetconfServiceProvider(address=address,
+                                      username=USERNAME,
+                                      password=PASSWORD)
+
+    # create CRUD service
+    crud = CRUDService()
+
+    return provider, crud
+
+
+def format_validate_msg(status):
+    """Format validation message in color"""
+    OK = '\033[92m OK \033[0m'
+    FAIL = '\033[91mFAIL\033[0m'
+    if status:
+        return OK
+    else:
+        return FAIL
+
+
+def withdraw_peer_interface(provider, crud, peer):
+    """Withdraw peer interface configuration"""
+    # interface configuration filter
+    interfaces = oc_interfaces.Interfaces()
+    peer_interface_remove_filter(interfaces, 
+                                 name=peer["interface"]["name"])
+
+    # update configuration on NETCONF device
+    crud.update(provider, interfaces)
+
+
+def withdraw_bgp_peer(provider, crud, peer):
+    """Withdraw BGP peer configuration"""
+    # BGP configuration filter
+    bgp = oc_bgp.Bgp()
+    bgp_peer_remove_filter(bgp, 
+                           local_as=peer["as"],
+                           peer_address=peer["address"])
+
+    # update configuration on NETCONF device
+    crud.update(provider, bgp)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("peer_config_file_name",
+                        help="peer configuration file (JSON)")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    print("{}: Loading peer config ".format(datetime.datetime.now().time()).ljust(PLEN, PCHAR),
+          end='', flush=True)
+    config = load_peer_config_file(args.peer_config_file_name)
+    print(" [{}]".format(format_validate_msg(True)))
+
+    print("{}: Initializing connections ".format(datetime.datetime.now().time()).ljust(PLEN, PCHAR),
+          end='', flush=True)
+    provider, crud = init_connections(config["asbr"]["address"])
+    print(" [{}]".format(format_validate_msg(True)))
+
+    # remove peers
+    for peer in config["peers"]:
+        print("{}: Remove peer interface {} ".format(datetime.datetime.now().time(),
+                                                     peer["interface"]["name"]).ljust(PLEN, PCHAR),
+              end='', flush=True)
+        withdraw_peer_interface(provider, crud, peer)
+        print(" [{}]".format(format_validate_msg(True)))
+
+        print("{}: Remove BGP peer {} ".format(datetime.datetime.now().time(),
+                                                      peer["address"]).ljust(PLEN, PCHAR),
+              end='', flush=True)
+        withdraw_bgp_peer(provider, crud, peer)
+        print(" [{}]".format(format_validate_msg(True)))
+
+    sys.exit()
+# End of script


### PR DESCRIPTION
Demonstrates basic BGP peer deployment using OpenConfig data models. The
setup uses YDK for configuration changes and Pipeline/Kafka for
streaming telemetry.  Operational validations are implemented in Python
using a simple Kafka consumer that monitors interface and BGP session
state.  Files:
README.md - Demo description and running instructions
consume_telemetry.py - consume streaming telemetry data from kafka bus
config_bgp_peer.py
config_peer_interface.py - create configuration for BGP peer
deploy_peers.py - deploy peer configuration
remove_bgp_peer.py - remove configuration for BGP peer
remove_peer_interface.py - remove configuration for peer interface
validate_bgp_peer.py - validate BGP peer operation
validate_peer_interface.py - validate peer interface operation
withdraw_peers.py - withdraw peer configuration
pipeline.conf - pipeline configuration
peer.json - peer configuration to deploy/withdraw