### PR TITLE
 Add sample apps for encoding XE OSPF config

### DIFF
--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-20-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-20-ydk.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-router-ospf-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
+
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.255.255"
+    network.area = 0
+
+    ospf.network.append(network)
+    native.router.ospf.append(ospf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-20-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-20-ydk.xml
@@ -1,0 +1,17 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.255.255</mask>
+        <area>0</area>
+      </network>
+    </ospf>
+  </router>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-30-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-30-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-router-ospf-30-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
+
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+    native.router.ospf.append(ospf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-30-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-30-ydk.xml
@@ -1,0 +1,22 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+    </ospf>
+  </router>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-32-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-32-ydk.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-router-ospf-32-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
+
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+
+    # OSPF stub Area
+    area = ospf.Area()
+    area.id = 1
+    area.stub = area.Stub()
+    ospf.area.append(area)
+
+    native.router.ospf.append(ospf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-32-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-32-ydk.xml
@@ -1,0 +1,26 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <area>
+        <id>1</id>
+        <stub/>
+      </area>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+    </ospf>
+  </router>
+</native>
+

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-34-ydk.py
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-34-ydk.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model Cisco-IOS-XE-native.
+
+usage: cd-encode-xe-native-router-ospf-34-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.cisco_ios_xe import Cisco_IOS_XE_native \
+    as xe_native
+from ydk.types import Empty
+import logging
+
+
+def config_native(native):
+    """Add config data to native object."""
+    # OSPF process
+    ospf = native.router.Ospf()
+    ospf.id = 172
+    ospf.router_id = "172.16.255.1"
+
+    ospf.passive_interface.interface = "Loopback0"
+
+    network = ospf.Network()
+    network.ip = "172.16.0.0"
+    network.mask = "0.0.0.255"
+    network.area = 0
+
+    ospf.network.append(network)
+
+    network = ospf.Network()
+    network.ip = "172.16.1.0"
+    network.mask = "0.0.0.255"
+    network.area = 1
+
+    ospf.network.append(network)
+
+    # OSPF stub Area
+    area = ospf.Area()
+    area.id = 1
+    stub = area.Stub()
+    stub.no_summary = Empty()
+    area.stub = stub
+    ospf.area.append(area)
+
+    native.router.ospf.append(ospf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    native = xe_native.Native()  # create object
+    config_native(native)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, native))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-34-ydk.xml
+++ b/samples/basic/codec/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/cd-encode-xe-native-router-ospf-34-ydk.xml
@@ -1,0 +1,28 @@
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+  <router>
+    <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+      <id>172</id>
+      <router-id>172.16.255.1</router-id>
+      <area>
+        <id>1</id>
+        <stub>
+          <no-summary/>
+        </stub>
+      </area>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
+      <network>
+        <ip>172.16.0.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>0</area>
+      </network>
+      <network>
+        <ip>172.16.1.0</ip>
+        <mask>0.0.0.255</mask>
+        <area>1</area>
+      </network>
+    </ospf>
+  </router>
+</native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.py
@@ -56,6 +56,7 @@ def config_native(native):
     ospf.network.append(network)
     native.router.ospf.append(ospf)
 
+
 if __name__ == "__main__":
     """Execute main program."""
     parser = ArgumentParser()

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-20-ydk.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0"?>
-<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
   <router>
     <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
       <id>172</id>
       <router-id>172.16.255.1</router-id>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
       <network>
         <ip>172.16.0.0</ip>
         <mask>0.0.255.255</mask>
         <area>0</area>
       </network>
-      <passive-interface>
-        <interface>Loopback0</interface>
-      </passive-interface>
     </ospf>
   </router>
 </native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.py
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.py
@@ -63,6 +63,7 @@ def config_native(native):
     ospf.network.append(network)
     native.router.ospf.append(ospf)
 
+
 if __name__ == "__main__":
     """Execute main program."""
     parser = ArgumentParser()

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-30-ydk.xml
@@ -1,9 +1,11 @@
-<?xml version="1.0"?>
-<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
   <router>
     <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
       <id>172</id>
       <router-id>172.16.255.1</router-id>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
       <network>
         <ip>172.16.0.0</ip>
         <mask>0.0.0.255</mask>
@@ -14,9 +16,7 @@
         <mask>0.0.0.255</mask>
         <area>1</area>
       </network>
-      <passive-interface>
-        <interface>Loopback0</interface>
-      </passive-interface>
     </ospf>
   </router>
 </native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-32-ydk.xml
@@ -1,12 +1,15 @@
-<?xml version="1.0"?>
-<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
   <router>
     <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
       <id>172</id>
       <router-id>172.16.255.1</router-id>
       <area>
         <id>1</id>
+        <stub/>
       </area>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
       <network>
         <ip>172.16.0.0</ip>
         <mask>0.0.0.255</mask>
@@ -17,9 +20,7 @@
         <mask>0.0.0.255</mask>
         <area>1</area>
       </network>
-      <passive-interface>
-        <interface>Loopback0</interface>
-      </passive-interface>
     </ospf>
   </router>
 </native>
+

--- a/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.xml
+++ b/samples/basic/crud/models/cisco-ios-xe/Cisco-IOS-XE-native/native/router/ospf/nc-create-xe-native-router-ospf-34-ydk.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="merge">
+<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
   <router>
     <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
       <id>172</id>
@@ -10,6 +9,9 @@
           <no-summary/>
         </stub>
       </area>
+      <passive-interface>
+        <interface>Loopback0</interface>
+      </passive-interface>
       <network>
         <ip>172.16.0.0</ip>
         <mask>0.0.0.255</mask>
@@ -20,9 +22,7 @@
         <mask>0.0.0.255</mask>
         <area>1</area>
       </network>
-      <passive-interface>
-        <interface>Loopback0</interface>
-      </passive-interface>
     </ospf>
   </router>
 </native>
+


### PR DESCRIPTION
Includes four custom apps to encode config for XE interfaces in XML:
cd-encode-xe-native-router-ospf-20-ydk.py - single area ipv4 router
cd-encode-xe-native-router-ospf-30-ydk.py - ipv4 ABR
cd-encode-xe-native-router-ospf-32-ydk.py - ipv4 ABR with stub area
cd-encode-xe-native-router-ospf-34-ydk.py - ipv4 ABR with totally stub area

Includes commits with cosmetic fixes for XE OSPF CRUD files.