### PR TITLE
Add sample apps to encode OpenConfig LLDP configuration

### DIFF
--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-10-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-10-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-lldp.
+
+usage: cd-encode-oc-lldp-10-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_lldp \
+    as oc_lldp
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = oc_lldp.Lldp()  # create object
+    config_lldp(lldp)  # add object configuration
+
+    # encode and print object
+    # print(codec.encode(provider, lldp))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-20-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-20-ydk.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-lldp.
+
+usage: cd-encode-oc-lldp-20-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_lldp \
+    as oc_lldp
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.config.enabled = True
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = oc_lldp.Lldp()  # create object
+    config_lldp(lldp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, lldp))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-20-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-20-ydk.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<lldp xmlns="http://openconfig.net/yang/lldp">
+  <config>
+    <enabled>true</enabled>
+  </config>
+</lldp>

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-22-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-22-ydk.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-lldp.
+
+usage: cd-encode-oc-lldp-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_lldp \
+    as oc_lldp
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.config.enabled = True
+    lldp.config.hello_timer = 15
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = oc_lldp.Lldp()  # create object
+    config_lldp(lldp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, lldp))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-22-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-22-ydk.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<lldp xmlns="http://openconfig.net/yang/lldp">
+  <config>
+    <enabled>true</enabled>
+    <hello-timer>15</hello-timer>
+  </config>
+</lldp>

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-24-ydk.py
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-24-ydk.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode configuration for model openconfig-lldp.
+
+usage: cd-encode-oc-lldp-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.openconfig import openconfig_lldp \
+    as oc_lldp
+from ydk.models.openconfig import openconfig_lldp_types \
+    as oc_lldp_types
+import logging
+
+
+def config_lldp(lldp):
+    """Add config data to lldp object."""
+    lldp.config.enabled = True
+    lldp.config.hello_timer = 15
+    suppress_tlv_advertisement = oc_lldp_types.MANAGEMENTADDRESS()
+    lldp.config.suppress_tlv_advertisement.append(suppress_tlv_advertisement)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    lldp = oc_lldp.Lldp()  # create config object
+    config_lldp(lldp)  # add object configuration
+
+    # encode and print object
+    print(codec.encode(provider, lldp))
+
+    exit()
+# End of script

--- a/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-24-ydk.xml
+++ b/samples/basic/codec/models/openconfig/openconfig-lldp/cd-encode-oc-lldp-24-ydk.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<lldp xmlns="http://openconfig.net/yang/lldp">
+  <config>
+    <enabled>true</enabled>
+    <hello-timer>15</hello-timer>
+    <suppress-tlv-advertisement xmlns:oc-lldp-types="http://openconfig.net/yang/lldp/types">oc-lldp-types:MANAGEMENT_ADDRESS</suppress-tlv-advertisement>
+  </config>
+</lldp>


### PR DESCRIPTION
Includes one boilerplate app and two custom apps to configure LLDP
using Openconfig:
cd-encode-oc-lldp-10-ydk.py - encode boilerplate
cd-encode-oc-lldp-20-ydk.py - enable LLDP
cd-encode-oc-lldp-22-ydk.py - enable LLDP with timer
cd-encode-oc-lldp-24-ydk.py - enable LLDP with TLV adv