### PR TITLE
Add gNMI sample apps for OC routing policy config

### DIFF
--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model openconfig-routing-policy.
+
+usage: gn-create-oc-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.json
@@ -1,0 +1,30 @@
+{
+  "openconfig-routing-policy:routing-policy": {
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "POLICY1",
+          "config": {
+            "name": "POLICY1"
+          },
+          "statements": {
+            "statement": [
+              {
+                "name": "accept route",
+                "config": {
+                  "name": "accept route"
+                },
+                "actions": {
+                  "config": {
+                    "accept-route": [null]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model openconfig-routing-policy.
+
+usage: gn-create-oc-routing-policy-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure routing policy
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY1"
+    policy_definition.config.name = "POLICY1"
+    statement = policy_definition.statements.Statement()
+    statement.name = "accept route"
+    statement.config.name = "accept route"
+    statement.actions.config.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-22-ydk.txt
@@ -1,0 +1,6 @@
+route-policy POLICY1
+  #statement-name accept route
+  done
+end-policy
+!
+end

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.json
@@ -1,0 +1,107 @@
+{
+  "openconfig-routing-policy:routing-policy": {
+    "defined-sets": {
+      "openconfig-bgp-policy:bgp-defined-sets": {
+        "community-sets": {
+          "community-set": [
+            {
+              "community-set-name": "COMMUNITY-SET1",
+              "config": {
+                "community-set-name": "COMMUNITY-SET1",
+                "community-member": [
+                  "ios-regex '^65172:17...$'",
+                  "65172:16001"
+                ]
+              }
+            }
+          ]
+        },
+        "as-path-sets": {
+          "as-path-set": [
+            {
+              "as-path-set-name": "AS-PATH-SET1",
+              "config": {
+                "as-path-set-name": "AS-PATH-SET1",
+                "as-path-set-member": [
+                  "^65172"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "POLICY2",
+          "config": {
+            "name": "POLICY2"
+          },
+          "statements": {
+            "statement": [
+              {
+                "name": "community-set1",
+                "config": {
+                  "name": "community-set1"
+                },
+                "conditions": {
+                  "openconfig-bgp-policy:bgp-conditions": {
+                    "match-community-set": {
+                      "config": {
+                        "community-set": "COMMUNITY-SET1",
+                        "match-set-options": "ALL"
+                      }
+                    }
+                  }
+                },
+                "actions": {
+                  "config": {
+                    "accept-route": [null]
+                  }
+                }
+              },
+              {
+                "name": "as-path-set1",
+                "config": {
+                  "name": "as-path-set1"
+                },
+                "conditions": {
+                  "openconfig-bgp-policy:bgp-conditions": {
+                    "match-as-path-set": {
+                      "config": {
+                        "as-path-set": "AS-PATH-SET1",
+                        "match-set-options": "ANY"
+                      }
+                    }
+                  }
+                },
+                "actions": {
+                  "config": {
+                    "accept-route": [null]
+                  },
+                  "openconfig-bgp-policy:bgp-actions": {
+                    "config": {
+                      "set-local-pref": 50
+                    }
+                  }
+                }
+              },
+              {
+                "name": "reject route",
+                "config": {
+                  "name": "reject route"
+                },
+                "actions": {
+                  "config": {
+                    "reject-route": [null]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model openconfig-routing-policy.
+
+usage: gn-create-oc-routing-policy-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure as-path set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    as_path_set = bgp_defined_sets.as_path_sets.AsPathSet()
+    as_path_set.as_path_set_name = "AS-PATH-SET1"
+    as_path_set.config.as_path_set_name = "AS-PATH-SET1"
+    as_path_set.config.as_path_set_member.append("^65172")
+    bgp_defined_sets.as_path_sets.as_path_set.append(as_path_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET1"
+    community_set.config.community_set_name = "COMMUNITY-SET1"
+    community_set.config.community_member.append("ios-regex '^65172:17...$'")
+    community_set.config.community_member.append("65172:16001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY2"
+    policy_definition.config.name = "POLICY2"
+    # community-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "community-set1"
+    statement.config.name = "community-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_community_set = bgp_conditions.MatchCommunitySet()
+    match_community_set.config.community_set = "COMMUNITY-SET1"
+    match_set_options = oc_policy_types.MatchSetOptionsType.ALL
+    match_community_set.config.match_set_options = match_set_options
+    bgp_conditions.match_community_set = match_community_set
+    statement.actions.config.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # as-path-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "as-path-set1"
+    statement.config.name = "as-path-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_as_path_set = bgp_conditions.MatchAsPathSet()
+    match_as_path_set.config.as_path_set = "AS-PATH-SET1"
+    match_set_options = oc_policy_types.MatchSetOptionsType.ANY
+    match_as_path_set.config.match_set_options = match_set_options
+    bgp_conditions.match_as_path_set = match_as_path_set
+    statement.actions.bgp_actions.config.set_local_pref = 50
+    statement.actions.config.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject route"
+    statement.config.name = "reject route"
+    statement.actions.config.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-24-ydk.txt
@@ -1,0 +1,24 @@
+as-path-set AS-PATH-SET1
+  ios-regex '^65172'
+end-set
+!
+community-set COMMUNITY-SET1
+  ios-regex '^65172:17...$',
+  65172:16001
+end-set
+!
+route-policy POLICY2
+  #statement-name community-set1
+  if community matches-every COMMUNITY-SET1 then
+    done
+  endif
+  #statement-name as-path-set1
+  if as-path in AS-PATH-SET1 then
+    set local-preference 50
+    done
+  endif
+  #statement-name reject route
+  drop
+end-policy
+!
+end

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.json
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.json
@@ -1,0 +1,111 @@
+{
+  "openconfig-routing-policy:routing-policy": {
+    "defined-sets": {
+      "prefix-sets": {
+        "prefix-set": [
+          {
+            "prefix-set-name": "PREFIX-SET1",
+            "config": {
+              "prefix-set-name": "PREFIX-SET1"
+            },
+            "prefixes": {
+              "prefix": [
+                {
+                  "ip-prefix": "10.0.0.0/16",
+                  "masklength-range": "24..32",
+                  "config": {
+                    "ip-prefix": "10.0.0.0/16",
+                    "masklength-range": "24..32"
+                  }
+                },
+                {
+                  "ip-prefix": "172.0.0.0/8",
+                  "masklength-range": "16..32",
+                  "config": {
+                    "ip-prefix": "172.0.0.0/8",
+                    "masklength-range": "16..32"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "openconfig-bgp-policy:bgp-defined-sets": {
+        "community-sets": {
+          "community-set": [
+            {
+              "community-set-name": "COMMUNITY-SET2",
+              "config": {
+                "community-set-name": "COMMUNITY-SET2",
+                "community-member": [
+                  "65172:17001"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "POLICY3",
+          "config": {
+            "name": "POLICY3"
+          },
+          "statements": {
+            "statement": [
+              {
+                "name": "prefix-set1",
+                "config": {
+                  "name": "prefix-set1"
+                },
+                "conditions": {
+                  "match-prefix-set": {
+                    "config": {
+                      "prefix-set": "PREFIX-SET1",
+                      "match-set-options": "ANY"
+                    }
+                  }
+                },
+                "actions": {
+                  "config": {
+                    "accept-route": [null]
+                  },
+                  "openconfig-bgp-policy:bgp-actions": {
+                    "config": {
+                      "set-local-pref": 1000
+                    },
+                    "set-community": {
+                      "config": {
+                        "options": "REPLACE"
+                      },
+                      "reference": {
+                        "config": {
+                          "community-set-ref": "COMMUNITY-SET2"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "name": "reject",
+                "config": {
+                  "name": "reject"
+                },
+                "actions": {
+                  "config": {
+                    "reject-route": [null]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model openconfig-routing-policy.
+
+usage: gn-create-oc-routing-policy-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+from ydk.models.openconfig import openconfig_policy_types \
+    as oc_policy_types
+from ydk.models.openconfig import openconfig_bgp_policy \
+    as oc_bgp_policy
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure prefix set
+    prefix_set = routing_policy.defined_sets.prefix_sets.PrefixSet()
+    prefix_set.prefix_set_name = "PREFIX-SET1"
+    prefix_set.config.prefix_set_name = "PREFIX-SET1"
+    prefix = prefix_set.prefixes.Prefix()
+    prefix.ip_prefix = "10.0.0.0/16"
+    prefix.masklength_range = "24..32"
+    prefix.config.ip_prefix = "10.0.0.0/16"
+    prefix.config.masklength_range = "24..32"
+    prefix_set.prefixes.prefix.append(prefix)
+    prefix = prefix_set.prefixes.Prefix()
+    prefix.ip_prefix = "172.0.0.0/8"
+    prefix.masklength_range = "16..32"
+    prefix.config.ip_prefix = "172.0.0.0/8"
+    prefix.config.masklength_range = "16..32"
+    prefix_set.prefixes.prefix.append(prefix)
+    routing_policy.defined_sets.prefix_sets.prefix_set.append(prefix_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET2"
+    community_set.config.community_set_name = "COMMUNITY-SET2"
+    community_set.config.community_member.append("65172:17001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY3"
+    policy_definition.config.name = "POLICY3"
+    # prefix-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "prefix-set1"
+    statement.config.name = "prefix-set1"
+    match_prefix_set = statement.conditions.MatchPrefixSet()
+    match_prefix_set.config.prefix_set = "PREFIX-SET1"
+    match_set_options = oc_policy_types.MatchSetOptionsRestrictedType.ANY
+    match_prefix_set.config.match_set_options = match_set_options
+    statement.conditions.match_prefix_set = match_prefix_set
+    statement.actions.bgp_actions.config.set_local_pref = 1000
+    set_community = statement.actions.bgp_actions.SetCommunity()
+    set_community.reference.config.community_set_ref = "COMMUNITY-SET2"
+    set_community.config.options = oc_bgp_policy.BgpSetCommunityOptionType.REPLACE
+    statement.actions.bgp_actions.set_community = set_community
+    statement.actions.config.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject"
+    statement.config.name = "reject"
+    statement.actions.config.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.txt
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-26-ydk.txt
@@ -1,0 +1,21 @@
+prefix-set PREFIX-SET1
+  10.0.0.0/16 ge 24 le 32,
+  172.0.0.0/8 ge 16 le 32
+end-set
+!
+community-set COMMUNITY-SET2
+  65172:17001
+end-set
+!
+route-policy POLICY3
+  #statement-name prefix-set1
+  if destination in PREFIX-SET1 then
+    set local-preference 1000
+    set community COMMUNITY-SET2
+    done
+  endif
+  #statement-name reject
+  drop
+end-policy
+!
+end

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.json
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.json
@@ -1,0 +1,34 @@
+{
+  "openconfig-routing-policy:routing-policy": {
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "POLICY4",
+          "config": {
+            "name": "POLICY4"
+          },
+          "statements": {
+            "statement": [
+              {
+                "name": "next-hop-self",
+                "config": {
+                  "name": "next-hop-self"
+                },
+                "actions": {
+                  "config": {
+                    "accept-route": [null]
+                  },
+                  "openconfig-bgp-policy:bgp-actions": {
+                    "config": {
+                      "set-next-hop": "SELF"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model openconfig-routing-policy.
+
+usage: gn-create-oc-routing-policy-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+from ydk.models.openconfig import openconfig_bgp_policy as oc_bgp_policy
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY4"
+    policy_definition.config.name = "POLICY4"
+    statement = policy_definition.statements.Statement()
+    statement.name = "next-hop-self"
+    statement.config.name = "next-hop-self"
+    set_next_hop = oc_bgp_policy.BgpNextHopType.SELF
+    statement.actions.bgp_actions.config.set_next_hop = set_next_hop
+    statement.actions.config.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.txt
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-create-oc-routing-policy-28-ydk.txt
@@ -1,0 +1,7 @@
+route-policy POLICY4
+  #statement-name next-hop-self
+  set next-hop self
+  done
+end-policy
+!
+end

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-delete-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-delete-oc-routing-policy-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-routing-policy.
+
+usage: gn-delete-oc-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-delete-oc-routing-policy-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-delete-oc-routing-policy-20-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model openconfig-routing-policy.
+
+usage: gn-delete-oc-routing-policy-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+
+    # delete configuration on gNMI device
+    crud.delete(provider, routing_policy)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-read-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-read-oc-routing-policy-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model openconfig-routing-policy.
+
+usage: gn-read-oc-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_routing_policy(routing_policy):
+    """Process data in routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+
+    # read data from gNMI device
+    # routing_policy = crud.read(provider, routing_policy)
+    process_routing_policy(routing_policy)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-update-oc-routing-policy-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/openconfig/openconfig-routing-policy/gn-update-oc-routing-policy-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model openconfig-routing-policy.
+
+usage: gn-update-oc-routing-policy-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_routing_policy \
+    as oc_routing_policy
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, routing_policy)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and five custom apps to configure
routing policy using OpenConfig and CRUD/gNMI:
gn-create-oc-routing-policy-10-ydk.py - create boilerplate
gn-create-oc-routing-policy-22-ydk.py - accept all prefixes
gn-create-oc-routing-policy-24-ydk.py - match path/comm, set comm/lpref
gn-create-oc-routing-policy-26-ydk.py - match prefix, set comm/lpref
gn-create-oc-routing-policy-28-ydk.py - set next hop self
gn-delete-oc-routing-policy-10-ydk.py - delete boilerplate
gn-delete-oc-routing-policy-20-ydk.py - delete all policy configuration
gn-read-oc-routing-policy-10-ydk.py   - read boilerplate
gn-update-oc-routing-policy-10-ydk.py - update boilerplate