### PR TITLE
Add gNMI sample apps for time zone configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "PST",
+      "area-name": "PST8PDT"
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "PST"
+    time_zone.area_name = "PST8PDT"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+clock timezone PST PST8PDT
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "CST",
+      "area-name": "PRC"
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CST"
+    time_zone.area_name = "PRC"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone CST PRC
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "CET",
+      "area-name": "CET"
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CET"
+    time_zone.area_name = "CET"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone CET CET
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "BRT",
+      "area-name": "Brazil/East"
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "BRT"
+    time_zone.area_name = "Brazil/East"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone BRT Brazil/East
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "WAT",
+      "area-name": "Africa/Douala"
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "WAT"
+    time_zone.area_name = "Africa/Douala"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone WAT Africa/Douala
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-read-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-read-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-read-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_clock(clock):
+    """Process data in clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+
+    # read data from gNMI device
+    # clock = crud.read(provider, clock)
+    process_clock(clock)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-update-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-update-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-update-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, clock)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and six custom apps to configure
device time zone for XR data model using CRUD/gNMI:
gn-create-xr-infra-infra-clock-linux-cfg-10-ydk.py - create boilerplate
gn-create-xr-infra-infra-clock-linux-cfg-20-ydk.py - PST PST8PDT
gn-create-xr-infra-infra-clock-linux-cfg-22-ydk.py - CST PRC
gn-create-xr-infra-infra-clock-linux-cfg-24-ydk.py - CET CET
gn-create-xr-infra-infra-clock-linux-cfg-26-ydk.py - BRT Brazil/East
gn-create-xr-infra-infra-clock-linux-cfg-28-ydk.py - WAT Africa/Douala
gn-delete-xr-infra-infra-clock-linux-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-infra-infra-clock-linux-cfg-20-ydk.py - delete all tz cfg
gn-read-xr-infra-infra-clock-linux-cfg-10-ydk.py   - read boilerplate
gn-update-xr-infra-infra-clock-linux-cfg-10-ydk.py - update boilerplate