### PR TITLE
Add gNMI sample app for XR IPv6 DNS configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.json
@@ -1,0 +1,42 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "ipv4-hosts": {
+            "ipv4-host": [
+              {
+                "host-name": "east",
+                "address": [
+                  "172.16.1.1"
+                ]
+              },
+              {
+                "host-name": "west",
+                "address": [
+                  "172.16.1.2"
+                ]
+              },
+              {
+                "host-name": "north",
+                "address": [
+                  "172.16.1.3",
+                  "172.16.1.4"
+                ]
+              },
+              {
+                "host-name": "south",
+                "address": [
+                  "172.16.1.5",
+                  "172.16.1.6"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # host name "east"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "east"
+    ipv4_host.address.append("172.16.1.1")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "west"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "west"
+    ipv4_host.address.append("172.16.1.2")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "north"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "north"
+    ipv4_host.address.append("172.16.1.3")
+    ipv4_host.address.append("172.16.1.4")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "south"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "south"
+    ipv4_host.address.append("172.16.1.5")
+    ipv4_host.address.append("172.16.1.6")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-20-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain ipv4 host east 172.16.1.1
+domain ipv4 host west 172.16.1.2
+domain ipv4 host north 172.16.1.3 172.16.1.4
+domain ipv4 host south 172.16.1.5 172.16.1.6
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.json
@@ -1,0 +1,42 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "ipv6-hosts": {
+            "ipv6-host": [
+              {
+                "host-name": "east",
+                "address": [
+                  "2001:db8::1"
+                ]
+              },
+              {
+                "host-name": "west",
+                "address": [
+                  "2001:db8::2"
+                ]
+              },
+              {
+                "host-name": "north",
+                "address": [
+                  "2001:db8::3",
+                  "2001:db8::4"
+                ]
+              },
+              {
+                "host-name": "south",
+                "address": [
+                  "2001:db8::5",
+                  "2001:db8::6"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # host name "east"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "east"
+    ipv6_host.address.append("2001:db8::1")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "west"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "west"
+    ipv6_host.address.append("2001:db8::2")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "north"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "north"
+    ipv6_host.address.append("2001:db8::3")
+    ipv6_host.address.append("2001:db8::4")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "south"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "south"
+    ipv6_host.address.append("2001:db8::5")
+    ipv6_host.address.append("2001:db8::6")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-21-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain ipv6 host east 2001:db8::1
+domain ipv6 host west 2001:db8::2
+domain ipv6 host north 2001:db8::3 2001:db8::4
+domain ipv6 host south 2001:db8::5 2001:db8::6
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "name": "example.com",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "172.16.128.1"
+              },
+              {
+                "order": 1,
+                "server-address": "172.16.128.2"
+              },
+              {
+                "order": 2,
+                "server-address": "172.16.128.3"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    vrf.name = "example.com"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "172.16.128.1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "172.16.128.2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "172.16.128.3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-22-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain name example.com
+domain name-server 172.16.128.1
+domain name-server 172.16.128.2
+domain name-server 172.16.128.3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "name": "example.com",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "2001:db8:8000::1"
+              },
+              {
+                "order": 1,
+                "server-address": "2001:db8:8000::2"
+              },
+              {
+                "order": 2,
+                "server-address": "2001:db8:8000::3"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    vrf.name = "example.com"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:8000::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:8000::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:8000::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-23-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain name example.com
+domain name-server 2001:db8:8000::1
+domain name-server 2001:db8:8000::2
+domain name-server 2001:db8:8000::3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.json
@@ -1,0 +1,44 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "172.16.128.1"
+              },
+              {
+                "order": 1,
+                "server-address": "172.16.128.2"
+              },
+              {
+                "order": 2,
+                "server-address": "172.16.128.3"
+              }
+            ]
+          },
+          "lists": {
+            "list": [
+              {
+                "order": 0,
+                "list-name": "example.com"
+              },
+              {
+                "order": 1,
+                "list-name": "example.net"
+              },
+              {
+                "order": 2,
+                "list-name": "example.org"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "example.com"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "example.net"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "example.org"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "172.16.128.1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "172.16.128.2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "172.16.128.3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-24-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.0.1
+domain list example.com
+domain list example.net
+domain list example.org
+domain name-server 172.16.128.1
+domain name-server 172.16.128.2
+domain name-server 172.16.128.3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.json
@@ -1,0 +1,44 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "2001:db8:8000::1"
+              },
+              {
+                "order": 1,
+                "server-address": "2001:db8:8000::2"
+              },
+              {
+                "order": 2,
+                "server-address": "2001:db8:8000::3"
+              }
+            ]
+          },
+          "lists": {
+            "list": [
+              {
+                "order": 0,
+                "list-name": "example.com"
+              },
+              {
+                "order": 1,
+                "list-name": "example.net"
+              },
+              {
+                "order": 2,
+                "list-name": "example.org"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "example.com"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "example.net"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "example.org"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:8000::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:8000::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:8000::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-25-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.0.1
+domain list example.com
+domain list example.net
+domain list example.org
+domain name-server 2001:db8:8000::1
+domain name-server 2001:db8:8000::2
+domain name-server 2001:db8:8000::3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.json
@@ -1,0 +1,42 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "ipv4-hosts": {
+            "ipv4-host": [
+              {
+                "host-name": "ruby",
+                "address": [
+                  "192.168.0.1"
+                ]
+              },
+              {
+                "host-name": "flame",
+                "address": [
+                  "192.168.0.2"
+                ]
+              },
+              {
+                "host-name": "crimson",
+                "address": [
+                  "192.168.0.3",
+                  "192.168.0.4"
+                ]
+              },
+              {
+                "host-name": "raspberry",
+                "address": [
+                  "192.168.0.5",
+                  "192.168.0.6"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # host name "ruby"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "ruby"
+    ipv4_host.address.append("192.168.0.1")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "flame"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "flame"
+    ipv4_host.address.append("192.168.0.2")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "crimson"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "crimson"
+    ipv4_host.address.append("192.168.0.3")
+    ipv4_host.address.append("192.168.0.4")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    # host name "raspberry"
+    ipv4_host = vrf.ipv4_hosts.Ipv4Host()
+    ipv4_host.host_name = "raspberry"
+    ipv4_host.address.append("192.168.0.5")
+    ipv4_host.address.append("192.168.0.6")
+    vrf.ipv4_hosts.ipv4_host.append(ipv4_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-30-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED ipv4 host ruby 192.168.0.1
+domain vrf RED ipv4 host flame 192.168.0.2
+domain vrf RED ipv4 host crimson 192.168.0.3 192.168.0.4
+domain vrf RED ipv4 host raspberry 192.168.0.5 192.168.0.6
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.json
@@ -1,0 +1,42 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "ipv6-hosts": {
+            "ipv6-host": [
+              {
+                "host-name": "ruby",
+                "address": [
+                  "2001:db8:a::1"
+                ]
+              },
+              {
+                "host-name": "flame",
+                "address": [
+                  "2001:db8:a::2"
+                ]
+              },
+              {
+                "host-name": "crimson",
+                "address": [
+                  "2001:db8:a::3",
+                  "2001:db8:a::4"
+                ]
+              },
+              {
+                "host-name": "raspberry",
+                "address": [
+                  "2001:db8:a::5",
+                  "2001:db8:a::6"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-31-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # host name "ruby"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "ruby"
+    ipv6_host.address.append("2001:db8:a::1")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "flame"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "flame"
+    ipv6_host.address.append("2001:db8:a::2")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "crimson"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "crimson"
+    ipv6_host.address.append("2001:db8:a::3")
+    ipv6_host.address.append("2001:db8:a::4")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    # host name "raspberry"
+    ipv6_host = vrf.ipv6_hosts.Ipv6Host()
+    ipv6_host.host_name = "raspberry"
+    ipv6_host.address.append("2001:db8:a::5")
+    ipv6_host.address.append("2001:db8:a::6")
+    vrf.ipv6_hosts.ipv6_host.append(ipv6_host)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-31-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED ipv6 host ruby 2001:db8:a::1
+domain vrf RED ipv6 host flame 2001:db8:a::2
+domain vrf RED ipv6 host crimson 2001:db8:a::3 2001:db8:a::4
+domain vrf RED ipv6 host raspberry 2001:db8:a::5 2001:db8:a::6
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "name": "red.example",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "192.168.128.1"
+              },
+              {
+                "order": 1,
+                "server-address": "192.168.128.2"
+              },
+              {
+                "order": 2,
+                "server-address": "192.168.128.3"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    vrf.name = "red.example"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "192.168.128.1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "192.168.128.2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "192.168.128.3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-32-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED name red.example
+domain vrf RED name-server 192.168.128.1
+domain vrf RED name-server 192.168.128.2
+domain vrf RED name-server 192.168.128.3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "name": "red.example",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "2001:db8:800a::1"
+              },
+              {
+                "order": 1,
+                "server-address": "2001:db8:800a::2"
+              },
+              {
+                "order": 2,
+                "server-address": "2001:db8:800a::3"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-33-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    vrf.name = "red.example"
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:800a::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:800a::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:800a::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-33-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED name red.example
+domain vrf RED name-server 2001:db8:800a::1
+domain vrf RED name-server 2001:db8:800a::2
+domain vrf RED name-server 2001:db8:800a::3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.json
@@ -1,0 +1,44 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "192.168.128.1"
+              },
+              {
+                "order": 1,
+                "server-address": "192.168.128.2"
+              },
+              {
+                "order": 2,
+                "server-address": "192.168.128.3"
+              }
+            ]
+          },
+          "lists": {
+            "list": [
+              {
+                "order": 0,
+                "list-name": "rouge.example"
+              },
+              {
+                "order": 1,
+                "list-name": "vermelho.example"
+              },
+              {
+                "order": 2,
+                "list-name": "rojo.example"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "rouge.example"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "vermelho.example"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "rojo.example"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "192.168.128.1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "192.168.128.2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "192.168.128.3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-34-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.0.1
+domain vrf RED list rouge.example
+domain vrf RED list vermelho.example
+domain vrf RED list rojo.example
+domain vrf RED name-server 192.168.128.1
+domain vrf RED name-server 192.168.128.2
+domain vrf RED name-server 192.168.128.3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.json
@@ -1,0 +1,44 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "RED",
+          "servers": {
+            "server": [
+              {
+                "order": 0,
+                "server-address": "2001:db8:800a::1"
+              },
+              {
+                "order": 1,
+                "server-address": "2001:db8:800a::2"
+              },
+              {
+                "order": 2,
+                "server-address": "2001:db8:800a::3"
+              }
+            ]
+          },
+          "lists": {
+            "list": [
+              {
+                "order": 0,
+                "list-name": "rouge.example"
+              },
+              {
+                "order": 1,
+                "list-name": "vermelho.example"
+              },
+              {
+                "order": 2,
+                "list-name": "rojo.example"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-35-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "RED"
+    # first domain name
+    list = vrf.lists.List()
+    list.order = 0
+    list.list_name = "rouge.example"
+    vrf.lists.list.append(list)
+    # second domain name
+    list = vrf.lists.List()
+    list.order = 1
+    list.list_name = "vermelho.example"
+    vrf.lists.list.append(list)
+    # third domain name
+    list = vrf.lists.List()
+    list.order = 2
+    list.list_name = "rojo.example"
+    vrf.lists.list.append(list)
+
+    # first name server
+    server = vrf.servers.Server()
+    server.order = 0
+    server.server_address = "2001:db8:800a::1"
+    vrf.servers.server.append(server)
+    # second name server
+    server = vrf.servers.Server()
+    server.order = 1
+    server.server_address = "2001:db8:800a::2"
+    vrf.servers.server.append(server)
+    # third name server
+    server = vrf.servers.Server()
+    server.order = 2
+    server.server_address = "2001:db8:800a::3"
+    vrf.servers.server.append(server)
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-35-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.1.1
+domain vrf RED list rouge.example
+domain vrf RED list vermelho.example
+domain vrf RED list rojo.example
+domain vrf RED name-server 2001:db8:800a::1
+domain vrf RED name-server 2001:db8:800a::2
+domain vrf RED name-server 2001:db8:800a::3
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.json
@@ -1,0 +1,13 @@
+{
+  "Cisco-IOS-XR-ip-domain-cfg:ip-domain": {
+    "vrfs": {
+      "vrf": [
+        {
+          "vrf-name": "default",
+          "lookup": [null]
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-create-xr-ip-domain-cfg-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    vrf = ip_domain.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    vrf.lookup = Empty()
+    ip_domain.vrfs.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-create-xr-ip-domain-cfg-40-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.0.1
+domain lookup disable
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-delete-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-delete-xr-ip-domain-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-delete-xr-ip-domain-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-delete-xr-ip-domain-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-delete-xr-ip-domain-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-delete-xr-ip-domain-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, ip_domain)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-read-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-read-xr-ip-domain-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-read-xr-ip-domain-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ip_domain(ip_domain):
+    """Process data in ip_domain object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+
+    # read data from gNMI device
+    # ip_domain = crud.read(provider, ip_domain)
+    process_ip_domain(ip_domain)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-update-xr-ip-domain-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-domain-cfg/gn-update-xr-ip-domain-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-domain-cfg.
+
+usage: gn-update-xr-ip-domain-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_domain_cfg \
+    as xr_ip_domain_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ip_domain(ip_domain):
+    """Add config data to ip_domain object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ip_domain = xr_ip_domain_cfg.IpDomain()  # create object
+    config_ip_domain(ip_domain)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, ip_domain)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate and fourteen custom apps to configure IPv6 DNS for XR data model using CRUD/gNMI:
gn-create-xr-ip-domain-cfg-10-ydk.py - create boilerplate
gn-create-xr-ip-domain-cfg-20-ydk.py - static (local) hosts
gn-create-xr-ip-domain-cfg-21-ydk.py - static (local) IPv6 hosts
gn-create-xr-ip-domain-cfg-22-ydk.py - single domain, various servers
gn-create-xr-ip-domain-cfg-23-ydk.py - single domain, various IPv6 servers
gn-create-xr-ip-domain-cfg-24-ydk.py - various domains, various srvs
gn-create-xr-ip-domain-cfg-25-ydk.py - various domains, various IPv6 srvs
gn-create-xr-ip-domain-cfg-30-ydk.py - static (local) hosts / VRF
gn-create-xr-ip-domain-cfg-31-ydk.py - VRF-aware static (local) IPv6 hosts
gn-create-xr-ip-domain-cfg-32-ydk.py - single domain, various srvs / VRF
gn-create-xr-ip-domain-cfg-33-ydk.py - VRF/ single dom, various IPv6 srvs
gn-create-xr-ip-domain-cfg-34-ydk.py - various domains, various srvs/VRF
gn-create-xr-ip-domain-cfg-35-ydk.py - VRF/ various domains/IPv6 servers
gn-create-xr-ip-domain-cfg-40-ydk.py - disable domain lookup
gn-delete-xr-ip-domain-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-ip-domain-cfg-20-ydk.py - delete all domain configuration
gn-read-xr-ip-domain-cfg-10-ydk.py   - read boilerplate
gn-update-xr-ip-domain-cfg-10-ydk.py - update boilerplate