### PR TITLE
Add gNMI sample apps for XR IPv6 NTP configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.json
@@ -1,0 +1,24 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "default",
+          "peer-ipv4s": {
+            "peer-ipv4": [
+              {
+                "address-ipv4": "10.0.0.1",
+                "peer-type-ipv4": [
+                  {
+                    "peer-type": "server"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
+    peer_ipv4.address_ipv4 = "10.0.0.1"
+    peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
+    peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-20-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.1.1
+ntp
+ server 10.0.0.1
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.json
@@ -1,0 +1,24 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "default",
+          "peer-ipv6s": {
+            "peer-ipv6": [
+              {
+                "address-ipv6": "2001:db8::a:1",
+                "peer-type-ipv6": [
+                  {
+                    "peer-type": "server"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-21-ydk.txt
@@ -1,0 +1,4 @@
+ntp
+ server ipv6 2001:db8::a:1
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.json
@@ -1,0 +1,26 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "update-calendar": [null],
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "default",
+          "peer-ipv4s": {
+            "peer-ipv4": [
+              {
+                "address-ipv4": "10.0.0.1",
+                "peer-type-ipv4": [
+                  {
+                    "peer-type": "server",
+                    "source-interface": "Loopback0"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
+    peer_ipv4.address_ipv4 = "10.0.0.1"
+    peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_type_ipv4.source_interface = "Loopback0"
+    peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
+    peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-22-ydk.txt
@@ -1,0 +1,5 @@
+ntp
+ server 10.0.0.1 source Loopback0
+ update-calendar
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.json
@@ -1,0 +1,26 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "update-calendar": [null],
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "default",
+          "peer-ipv6s": {
+            "peer-ipv6": [
+              {
+                "address-ipv6": "2001:db8::a:1",
+                "peer-type-ipv6": [
+                  {
+                    "peer-type": "server",
+                    "source-interface": "Loopback0"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "default"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_type_ipv6.source_interface = "Loopback0"
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-23-ydk.txt
@@ -1,0 +1,5 @@
+ntp
+ server ipv6 2001:db8::a:1 source Loopback0
+ update-calendar
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "update-calendar": [null],
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "MGMT-PLANE",
+          "peer-ipv4s": {
+            "peer-ipv4": [
+              {
+                "address-ipv4": "10.0.0.1",
+                "peer-type-ipv4": [
+                  {
+                    "peer-type": "server",
+                    "ntp-version": 4,
+                    "preferred-peer": [null],
+                    "source-interface": "Loopback0",
+                    "iburst": [null]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "MGMT-PLANE"
+    peer_ipv4 = peer_vrf.peer_ipv4s.PeerIpv4()
+    peer_ipv4.address_ipv4 = "10.0.0.1"
+    peer_type_ipv4 = peer_ipv4.PeerTypeIpv4()
+    peer_type_ipv4.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_type_ipv4.ntp_version = 4
+    peer_type_ipv4.iburst = Empty()
+    peer_type_ipv4.preferred_peer = Empty()
+    peer_type_ipv4.source_interface = "Loopback0"
+    peer_ipv4.peer_type_ipv4.append(peer_type_ipv4)
+    peer_vrf.peer_ipv4s.peer_ipv4.append(peer_ipv4)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-24-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.0.1
+ntp
+ server vrf MGMT-PLANE 10.0.0.1 version 4 prefer iburst source Loopback0
+ update-calendar
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-ntp-cfg:ntp": {
+    "update-calendar": [null],
+    "peer-vrfs": {
+      "peer-vrf": [
+        {
+          "vrf-name": "MGMT-PLANE",
+          "peer-ipv6s": {
+            "peer-ipv6": [
+              {
+                "address-ipv6": "2001:db8::a:1",
+                "peer-type-ipv6": [
+                  {
+                    "peer-type": "server",
+                    "ntp-version": 4,
+                    "preferred-peer": [null],
+                    "source-interface": "Loopback0",
+                    "iburst": [null]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-create-xr-ip-ntp-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    peer_vrf = ntp.peer_vrfs.PeerVrf()
+    peer_vrf.vrf_name = "MGMT-PLANE"
+    peer_ipv6 = peer_vrf.peer_ipv6s.PeerIpv6()
+    peer_ipv6.address_ipv6 = "2001:db8::a:1"
+    peer_type_ipv6 = peer_ipv6.PeerTypeIpv6()
+    peer_type_ipv6.peer_type = xr_ip_ntp_cfg.NtpPeer.server
+    peer_type_ipv6.ntp_version = 4
+    peer_type_ipv6.iburst = Empty()
+    peer_type_ipv6.preferred_peer = Empty()
+    peer_type_ipv6.source_interface = "Loopback0"
+    peer_ipv6.peer_type_ipv6.append(peer_type_ipv6)
+    peer_vrf.peer_ipv6s.peer_ipv6.append(peer_ipv6)
+    ntp.peer_vrfs.peer_vrf.append(peer_vrf)
+    ntp.update_calendar = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-create-xr-ip-ntp-cfg-25-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.1.1
+ntp
+ server vrf MGMT-PLANE ipv6 2001:db8::a:1 version 4 prefer iburst source Loopback0
+ update-calendar
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-delete-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-delete-xr-ip-ntp-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-delete-xr-ip-ntp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-delete-xr-ip-ntp-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-delete-xr-ip-ntp-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-delete-xr-ip-ntp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, ntp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-read-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-read-xr-ip-ntp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-read-xr-ip-ntp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ntp(ntp):
+    """Process data in ntp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+
+    # read data from gNMI device
+    # ntp = crud.read(provider, ntp)
+    process_ntp(ntp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-update-xr-ip-ntp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-ntp-cfg/gn-update-xr-ip-ntp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-ntp-cfg.
+
+usage: gn-update-xr-ip-ntp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_ntp_cfg \
+    as xr_ip_ntp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ntp(ntp):
+    """Add config data to ntp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    ntp = xr_ip_ntp_cfg.Ntp()  # create object
+    config_ntp(ntp)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, ntp)
+
+    exit()
+# End of script


### PR DESCRIPTION
Introduces four boilerplate seven custom apps to configure IPv6 NTP for XR data model using CRUD/gNMI:
gn-create-xr-ip-ntp-cfg-10-ydk.py - create boilerplate
gn-create-xr-ip-ntp-cfg-20-ydk.py - IPv4 server
gn-create-xr-ip-ntp-cfg-21-ydk.py - IPv6 server
gn-create-xr-ip-ntp-cfg-22-ydk.py - IPv4 server w/source intf
gn-create-xr-ip-ntp-cfg-23-ydk.py - IPv6 server w/source intf
gn-create-xr-ip-ntp-cfg-24-ydk.py - VRF-aware NTPv4 with iburst
gn-create-xr-ip-ntp-cfg-25-ydk.py - VRF-aware NTPv6 with iburst
gn-delete-xr-ip-ntp-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-ip-ntp-cfg-20-ydk.py - delete all IPv6 NTP configuration
gn-read-xr-ip-ntp-cfg-10-ydk.py   - read boilerplate
gn-update-xr-ip-ntp-cfg-10-ydk.py - update boilerplate