### PR TITLE
Add gNMI sample app for XR RSVP-TE configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.json
@@ -1,0 +1,31 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-20-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth percentage 100
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth percentage 100
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-22-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth 1000000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth 1000000
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.json
@@ -1,0 +1,35 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "bc1-bandwidth": 25,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "bc1-bandwidth": 25,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-24-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.json
@@ -1,0 +1,33 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "bc1-bandwidth": 250000,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "bc1-bandwidth": 250000,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-26-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "mam": {
+              "max-resv-bandwidth": 1000000,
+              "bc0-bandwidth": 600000,
+              "bc1-bandwidth": 400000
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "mam": {
+              "max-resv-bandwidth": 1000000,
+              "bc0-bandwidth": 600000,
+              "bc1-bandwidth": 400000
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-create-xr-ip-rsvp-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-create-xr-ip-rsvp-cfg-28-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-delete-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-delete-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-delete-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-delete-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-delete-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-delete-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # delete configuration on gNMI device
+    crud.delete(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-read-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-read-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-read-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_rsvp(rsvp):
+    """Process data in rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # read data from gNMI device
+    # rsvp = crud.read(provider, rsvp)
+    process_rsvp(rsvp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-update-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-update-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-update-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, rsvp)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate and six custom apps to configure RSVP-TE (non-DS-TE and DS-TE with RDM/MAM bandwidth pools) for XR data model using CRUD/gNMI:

gn-create-xr-ip-rsvp-cfg-10-ydk.py - create boilerplate
gn-create-xr-ip-rsvp-cfg-20-ydk.py - interface BW percentage
gn-create-xr-ip-rsvp-cfg-22-ydk.py - interface BW absolute
gn-create-xr-ip-rsvp-cfg-24-ydk.py - interface RDM BW percentage
gn-create-xr-ip-rsvp-cfg-26-ydk.py - interface RDM BW absolute
gn-create-xr-ip-rsvp-cfg-28-ydk.py - interface MAM BW
gn-delete-xr-ip-rsvp-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-ip-rsvp-cfg-20-ydk.py - delete all RSVP configuration
gn-read-xr-ip-rsvp-cfg-10-ydk.py   - read boilerplate
gn-update-xr-ip-rsvp-cfg-10-ydk.py - update boilerplate