### PR TITLE
Add gNMI sample app for XR static routing configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.json
@@ -1,0 +1,30 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv4": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "0.0.0.0",
+                  "prefix-length": 0,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-next-hop-address": [
+                        {
+                          "next-hop-address": "172.16.1.3"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "0.0.0.0"
+    vrf_prefix.prefix_length = 0
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "172.16.1.3"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-20-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv4 unicast
+  0.0.0.0/0 172.16.1.3
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.json
@@ -1,0 +1,30 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv6": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "::",
+                  "prefix-length": 0,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-next-hop-address": [
+                        {
+                          "next-hop-address": "2001:db8::1:3"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "::0"
+    vrf_prefix.prefix_length = 0
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-21-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  ::/0 2001:db8::1:3
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.json
@@ -1,0 +1,30 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv4": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "172.16.0.0",
+                  "prefix-length": 16,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-interface-name": [
+                        {
+                          "interface-name": "Null0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "172.16.0.0"
+    vrf_prefix.prefix_length = 16
+    vrf_next_hop_interface_name = vrf_prefix.vrf_route. \
+        vrf_next_hop_table.VrfNextHopInterfaceName()
+    vrf_next_hop_interface_name.interface_name = "Null0"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_interface_name. \
+        append(vrf_next_hop_interface_name)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-22-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv4 unicast
+  172.16.0.0/16 Null0
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.json
@@ -1,0 +1,30 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv6": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "2001:db8:a::",
+                  "prefix-length": 64,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-interface-name": [
+                        {
+                          "interface-name": "Null0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_interface_name = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopInterfaceName()
+    vrf_next_hop_interface_name.interface_name = "Null0"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_interface_name. \
+        append(vrf_next_hop_interface_name)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-23-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  2001:db8:a::/64 Null0
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.json
@@ -1,0 +1,32 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv4": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "172.16.0.0",
+                  "prefix-length": 16,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-next-hop-address": [
+                        {
+                          "next-hop-address": "172.16.1.3",
+                          "metric": 254,
+                          "object-name": "TRACKED_OBJ"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "172.16.0.0"
+    vrf_prefix.prefix_length = 16
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "172.16.1.3"
+    vrf_next_hop_next_hop_address.metric = 254
+    vrf_next_hop_next_hop_address.object_name = "TRACKED_OBJ"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-24-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv4 unicast
+  172.16.0.0/16 172.16.1.3 254 track TRACKED_OBJ
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.json
@@ -1,0 +1,32 @@
+{
+  "Cisco-IOS-XR-ip-static-cfg:router-static": {
+    "default-vrf": {
+      "address-family": {
+        "vrfipv6": {
+          "vrf-unicast": {
+            "vrf-prefixes": {
+              "vrf-prefix": [
+                {
+                  "prefix": "2001:db8:a::",
+                  "prefix-length": 64,
+                  "vrf-route": {
+                    "vrf-next-hop-table": {
+                      "vrf-next-hop-next-hop-address": [
+                        {
+                          "next-hop-address": "2001:db8::1:3",
+                          "metric": 254,
+                          "object-name": "TRACKED_OBJ"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-create-xr-ip-static-cfg-25-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv6.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "2001:db8:a::"
+    vrf_prefix.prefix_length = 64
+    vrf_next_hop_next_hop_address = vrf_prefix.vrf_route.vrf_next_hop_table. \
+        VrfNextHopNextHopAddress()
+    vrf_next_hop_next_hop_address.next_hop_address = "2001:db8::1:3"
+    vrf_next_hop_next_hop_address.metric = 254
+    vrf_next_hop_next_hop_address.object_name = "TRACKED_OBJ"
+    vrf_prefix.vrf_route.vrf_next_hop_table.vrf_next_hop_next_hop_address. \
+        append(vrf_next_hop_next_hop_address)
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-create-xr-ip-static-cfg-25-ydk.txt
@@ -1,0 +1,7 @@
+router static
+ address-family ipv6 unicast
+  2001:db8:a::/64 2001:db8::1:3 254 track TRACKED_OBJ
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-delete-xr-ip-static-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-delete-xr-ip-static-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, router_static)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-30-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-30-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-delete-xr-ip-static-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider,
+                router_static.default_vrf.address_family.vrfipv4.vrf_unicast)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-31-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-31-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-delete-xr-ip-static-cfg-31-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider,
+                router_static.default_vrf.address_family.vrfipv6.vrf_unicast)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-40-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-delete-xr-ip-static-cfg-40-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-delete-xr-ip-static-cfg-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    vrf_unicast = router_static.default_vrf.address_family.vrfipv4.vrf_unicast
+    vrf_prefix = vrf_unicast.vrf_prefixes.VrfPrefix()
+    vrf_prefix.prefix = "172.16.0.0"
+    vrf_prefix.prefix_length = 16
+    vrf_unicast.vrf_prefixes.vrf_prefix.append(vrf_prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # delete configuration on gNMI device
+    crud.delete(provider,
+                router_static.default_vrf.address_family.vrfipv4.vrf_unicast.vrf_prefixes.vrf_prefix[0])
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-read-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-read-xr-ip-static-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-read-xr-ip-static-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_router_static(router_static):
+    """Process data in router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+
+    # read data from gNMI device
+    # router_static = crud.read(provider, router_static)
+    process_router_static(router_static)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-update-xr-ip-static-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-static-cfg/gn-update-xr-ip-static-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ip-static-cfg.
+
+usage: gn-update-xr-ip-static-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_static_cfg \
+    as xr_ip_static_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_router_static(router_static):
+    """Add config data to router_static object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    router_static = xr_ip_static_cfg.RouterStatic()  # create object
+    config_router_static(router_static)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, router_static)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and eight custom apps to configure
static routing for XR data model using CRUD/gNMI:
gn-create-xr-ip-static-cfg-10-ydk.py - create boilerplate
gn-create-xr-ip-static-cfg-20-ydk.py - IPv4 route to next-hop address
gn-create-xr-ip-static-cfg-21-ydk.py - IPv6 route to next-hop address
gn-create-xr-ip-static-cfg-22-ydk.py - IPv4 route to Null0
gn-create-xr-ip-static-cfg-23-ydk.py - IPv6 route to Null0
gn-create-xr-ip-static-cfg-24-ydk.py - IPv4 route with attributes
gn-create-xr-ip-static-cfg-25-ydk.py - IPv6 route with attributes
gn-delete-xr-ip-static-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-ip-static-cfg-31-ydk.py - delete all IPv6 routes
gn-delete-xr-ip-static-cfg-40-ydk.py - delete IPv4 route
gn-read-xr-ip-static-cfg-10-ydk.py   - read boilerplate
gn-update-xr-ip-static-cfg-10-ydk.py - update boilerplate