### PR TITLE
Add gNMI sample app for XR BGP configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.json
@@ -1,0 +1,64 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "172.16.255.2",
+                          "neighbor-group-add-member": "IBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "IBGP",
+                          "update-source-interface": "Loopback0",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv4-unicast",
+                                "activate": [null]
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65001
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv4-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "IBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65001
+    neighbor_group.update_source_interface = "Loopback0"
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4 unicast
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "172.16.255.2"
+    neighbor.neighbor_group_add_member = "IBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-40-ydk.txt
@@ -1,0 +1,14 @@
+router bgp 65001
+ address-family ipv4 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv4 unicast
+  !
+ !
+ neighbor 172.16.255.2
+  use neighbor-group IBGP
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.json
@@ -1,0 +1,64 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "2001:db8::ff:2",
+                          "neighbor-group-add-member": "IBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "IBGP",
+                          "update-source-interface": "Loopback0",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv6-unicast",
+                                "activate": [null]
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65001
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv6-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-41-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "IBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65001
+    neighbor_group.update_source_interface = "Loopback0"
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4 unicast
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.neighbor_group_add_member = "IBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-41-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv6 unicast
+  !
+ !
+ neighbor 2001:db8::ff:2
+  use neighbor-group IBGP
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.json
@@ -1,0 +1,65 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "172.16.255.2",
+                          "neighbor-group-add-member": "IBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "IBGP",
+                          "update-source-interface": "Loopback0",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv4-unicast",
+                                "activate": [null],
+                                "route-policy-out": "POLICY2"
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65001
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv4-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-42-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "IBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65001
+    neighbor_group.update_source_interface = "Loopback0"
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4-unicast address family
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "172.16.255.2"
+    neighbor.neighbor_group_add_member = "IBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-42-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv4 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv4 unicast
+   route-policy POLICY2 out
+  !
+ !
+ neighbor 172.16.255.2
+  use neighbor-group IBGP
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.json
@@ -1,0 +1,65 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "2001:db8::ff:2",
+                          "neighbor-group-add-member": "IBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "IBGP",
+                          "update-source-interface": "Loopback0",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv6-unicast",
+                                "activate": [null],
+                                "route-policy-out": "POLICY2"
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65001
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv6-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-43-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "IBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65001
+    neighbor_group.update_source_interface = "Loopback0"
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4-unicast address family
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_af.route_policy_out = "POLICY2"  # must be pre-configured
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8::ff:2"
+    neighbor.neighbor_group_add_member = "IBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-43-ydk.txt
@@ -1,0 +1,16 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group IBGP
+  remote-as 65001
+  update-source Loopback0
+  address-family ipv6 unicast
+   route-policy POLICY2 out
+  !
+ !
+ neighbor 2001:db8::ff:2
+  use neighbor-group IBGP
+ !
+!
+end
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.json
@@ -1,0 +1,65 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "192.168.1.1",
+                          "neighbor-group-add-member": "EBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "EBGP",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv4-unicast",
+                                "activate": [null],
+                                "route-policy-in": "POLICY3",
+                                "route-policy-out": "POLICY1"
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65002
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv4-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-44-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "EBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65002
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4-unicast address family
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv4_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
+    neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "192.168.1.1"
+    neighbor.neighbor_group_add_member = "EBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-44-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv4 unicast
+ !
+ neighbor-group EBGP
+  remote-as 65002
+  address-family ipv4 unicast
+   route-policy POLICY3 in
+   route-policy POLICY1 out
+  !
+ !
+ neighbor 192.168.1.1
+  use neighbor-group EBGP
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.json
@@ -1,0 +1,65 @@
+{
+  "Cisco-IOS-XR-ipv4-bgp-cfg:bgp": {
+    "instance": [
+      {
+        "instance-name": "default",
+        "instance-as": [
+          {
+            "as": 0,
+            "four-byte-as": [
+              {
+                "as": 65001,
+                "bgp-running": [null],
+                "default-vrf": {
+                  "bgp-entity": {
+                    "neighbors": {
+                      "neighbor": [
+                        {
+                          "neighbor-address": "2001:db8:e:1::1",
+                          "neighbor-group-add-member": "EBGP"
+                        }
+                      ]
+                    },
+                    "neighbor-groups": {
+                      "neighbor-group": [
+                        {
+                          "neighbor-group-name": "EBGP",
+                          "create": [null],
+                          "neighbor-group-afs": {
+                            "neighbor-group-af": [
+                              {
+                                "af-name": "ipv6-unicast",
+                                "activate": [null],
+                                "route-policy-in": "POLICY3",
+                                "route-policy-out": "POLICY1"
+                              }
+                            ]
+                          },
+                          "remote-as": {
+                            "as-xx": 0,
+                            "as-yy": 65002
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "global": {
+                    "global-afs": {
+                      "global-af": [
+                        {
+                          "af-name": "ipv6-unicast",
+                          "enable": [null]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-create-xr-ipv4-bgp-cfg-45-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_datatypes \
+    as xr_ipv4_bgp_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    # global configuration
+    instance = bgp.Instance()
+    instance.instance_name = "default"
+    instance_as = instance.InstanceAs()
+    instance_as.as_ = 0
+    four_byte_as = instance_as.FourByteAs()
+    four_byte_as.as_ = 65001
+    four_byte_as.bgp_running = Empty()
+    # global address family
+    global_af = four_byte_as.default_vrf.global_.global_afs.GlobalAf()
+    global_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    global_af.enable = Empty()
+    four_byte_as.default_vrf.global_.global_afs.global_af.append(global_af)
+    instance_as.four_byte_as.append(four_byte_as)
+    instance.instance_as.append(instance_as)
+    bgp.instance.append(instance)
+
+    # configure IBGP neighbor group
+    neighbor_groups = four_byte_as.default_vrf.bgp_entity.neighbor_groups
+    neighbor_group = neighbor_groups.NeighborGroup()
+    neighbor_group.neighbor_group_name = "EBGP"
+    neighbor_group.create = Empty()
+    # remote AS
+    neighbor_group.remote_as.as_xx = 0
+    neighbor_group.remote_as.as_yy = 65002
+    neighbor_groups.neighbor_group.append(neighbor_group)
+    # ipv4-unicast address family
+    neighbor_group_af = neighbor_group.neighbor_group_afs.NeighborGroupAf()
+    neighbor_group_af.af_name = xr_ipv4_bgp_datatypes.BgpAddressFamily.ipv6_unicast
+    neighbor_group_af.activate = Empty()
+    neighbor_group_af.route_policy_in = "POLICY3"  # must be pre-configured
+    neighbor_group_af.route_policy_out = "POLICY1"  # must be pre-configured
+    neighbor_group_afs = neighbor_group.neighbor_group_afs
+    neighbor_group_afs.neighbor_group_af.append(neighbor_group_af)
+
+    # configure IBGP neighbor
+    neighbor = four_byte_as.default_vrf.bgp_entity.neighbors.Neighbor()
+    neighbor.neighbor_address = "2001:db8:e:1::1"
+    neighbor.neighbor_group_add_member = "EBGP"
+    four_byte_as.default_vrf.bgp_entity.neighbors.neighbor.append(neighbor)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-create-xr-ipv4-bgp-cfg-45-ydk.txt
@@ -1,0 +1,15 @@
+router bgp 65001
+ address-family ipv6 unicast
+ !
+ neighbor-group EBGP
+  remote-as 65002
+  address-family ipv6 unicast
+   route-policy POLICY3 in
+   route-policy POLICY1 out
+  !
+ !
+ neighbor 2001:db8:e:1::1
+  use neighbor-group EBGP
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-delete-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-delete-xr-ipv4-bgp-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-delete-xr-ipv4-bgp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-delete-xr-ipv4-bgp-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-delete-xr-ipv4-bgp-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-delete-xr-ipv4-bgp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, bgp)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-read-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-read-xr-ipv4-bgp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-read-xr-ipv4-bgp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_bgp(bgp):
+    """Process data in bgp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+
+    # read data from gNMI device
+    # bgp = crud.read(provider, bgp)
+    process_bgp(bgp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-update-xr-ipv4-bgp-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-bgp-cfg/gn-update-xr-ipv4-bgp-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-ipv4-bgp-cfg.
+
+usage: gn-update-xr-ipv4-bgp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_bgp_cfg \
+    as xr_ipv4_bgp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_bgp(bgp):
+    """Add config data to bgp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    bgp = xr_ipv4_bgp_cfg.Bgp()  # create object
+    config_bgp(bgp)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, bgp)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and seven custom apps to configure BGP for XR data model using CRUD/gNMI:
gn-create-xr-ipv4-bgp-cfg-10-ydk.py - create boilerplate
gn-create-xr-ipv4-bgp-cfg-40-ydk.py - iBGP IPv4 neighbor grp w/o policy
gn-create-xr-ipv4-bgp-cfg-41-ydk.py - iBGP IPv6 neighbor grp w/o policy
gn-create-xr-ipv4-bgp-cfg-42-ydk.py - iBGP IPv4 neighbor grp w/ policy
gn-create-xr-ipv4-bgp-cfg-43-ydk.py - iBGP IPv6 neighbor group w/ policy
gn-create-xr-ipv4-bgp-cfg-44-ydk.py - eBGP IPv4 neighbor grp w/ policy
gn-create-xr-ipv4-bgp-cfg-45-ydk.py - eBGP IPv6 neighbor grp w/ policy
gn-delete-xr-ipv4-bgp-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-ipv4-bgp-cfg-20-ydk.py - delete all BGP configuration
gn-read-xr-ipv4-bgp-cfg-10-ydk.py   - read boilerplate
gn-update-xr-ipv4-bgp-cfg-10-ydk.py - update boilerplate