### PR TITLE
Add gNMI sample app for XR SR mapping configuration

### DIFF
--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-create-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on gNMI device
+    # crud.create(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.json
@@ -1,0 +1,16 @@
+{
+  "Cisco-IOS-XR-segment-routing-ms-cfg:sr": {
+    "mappings": {
+      "mapping": [
+        {
+          "af": "ipv4",
+          "ip": "172.16.255.1",
+          "mask": 32,
+          "sid-start": 4041,
+          "sid-range": 1
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-create-xr-segment-routing-ms-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv4
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-20-ydk.txt
@@ -1,0 +1,11 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv4
+    172.16.255.1/32 4041 range 1
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.json
@@ -1,0 +1,16 @@
+{
+  "Cisco-IOS-XR-segment-routing-ms-cfg:sr": {
+    "mappings": {
+      "mapping": [
+        {
+          "af": "ipv6",
+          "ip": "2001:db8::ff:1",
+          "mask": 128,
+          "sid-start": 4061,
+          "sid-range": 1
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-create-xr-segment-routing-ms-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv6
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-21-ydk.txt
@@ -1,0 +1,11 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv6
+    2001:db8::ff:1/128 4061 range 1
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.json
@@ -1,0 +1,23 @@
+{
+  "Cisco-IOS-XR-segment-routing-ms-cfg:sr": {
+    "mappings": {
+      "mapping": [
+        {
+          "af": "ipv4",
+          "ip": "172.16.255.1",
+          "mask": 32,
+          "sid-start": 4041,
+          "sid-range": 1
+        },
+        {
+          "af": "ipv4",
+          "ip": "172.17.255.1",
+          "mask": 32,
+          "sid-start": 5041,
+          "sid-range": 8
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-create-xr-segment-routing-ms-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv4
+    mapping.ip = "172.16.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 4041
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+    # second set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv4
+    mapping.ip = "172.17.255.1"
+    mapping.mask = 32
+    mapping.sid_start = 5041
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-22-ydk.txt
@@ -1,0 +1,12 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv4
+    172.16.255.1/32 4041 range 1
+    172.17.255.1/32 5041 range 8
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.json
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.json
@@ -1,0 +1,23 @@
+{
+  "Cisco-IOS-XR-segment-routing-ms-cfg:sr": {
+    "mappings": {
+      "mapping": [
+        {
+          "af": "ipv6",
+          "ip": "2001:db8::ff:1",
+          "mask": 128,
+          "sid-start": 4061,
+          "sid-range": 1
+        },
+        {
+          "af": "ipv6",
+          "ip": "2001:db8::1ff:1",
+          "mask": 128,
+          "sid-start": 5061,
+          "sid-range": 8
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Create configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-create-xr-segment-routing-ms-cfg-23-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv6
+    mapping.ip = "2001:db8::ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 4061
+    mapping.sid_range = 1
+    sr.mappings.mapping.append(mapping)
+    # first set of mappings
+    mapping = sr.mappings.Mapping()
+    mapping.af = xr_segment_routing_ms_cfg.SrmsAddressFamily.ipv6
+    mapping.ip = "2001:db8::1ff:1"
+    mapping.mask = 128
+    mapping.sid_start = 5061
+    mapping.sid_range = 8
+    sr.mappings.mapping.append(mapping)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # create configuration on gNMI device
+    crud.create(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.txt
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-create-xr-segment-routing-ms-cfg-23-ydk.txt
@@ -1,0 +1,12 @@
+!! IOS XR Configuration version = 6.1.2
+segment-routing
+ mapping-server
+  prefix-sid-map
+   address-family ipv6
+    2001:db8::ff:1/128 4061 range 1
+    2001:db8::1ff:1/128 5061 range 8
+   !
+  !
+ !
+!
+end

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-delete-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-delete-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-delete-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+
+    # delete configuration on gNMI device
+    # crud.delete(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-delete-xr-segment-routing-ms-cfg-20-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-delete-xr-segment-routing-ms-cfg-20-ydk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Delete all config data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-delete-xr-segment-routing-ms-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    # delete configuration on gNMI device
+    crud.delete(provider, sr)
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-read-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-read-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Read all data for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-read-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_sr(sr):
+    """Process data in sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+
+    # read data from gNMI device
+    # sr = crud.read(provider, sr)
+    process_sr(sr)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-update-xr-segment-routing-ms-cfg-10-ydk.py
+++ b/samples/basic/crud/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-segment-routing-ms-cfg/gn-update-xr-segment-routing-ms-cfg-10-ydk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Update configuration for model Cisco-IOS-XR-segment-routing-ms-cfg.
+
+usage: gn-update-xr-segment-routing-ms-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.services import CRUDService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_segment_routing_ms_cfg \
+    as xr_segment_routing_ms_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_sr(sr):
+    """Add config data to sr object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create CRUD service
+    crud = CRUDService()
+
+    sr = xr_segment_routing_ms_cfg.Sr()  # create object
+    config_sr(sr)  # add object configuration
+
+    # update configuration on gNMI device
+    # crud.update(provider, sr)
+
+    exit()
+# End of script


### PR DESCRIPTION
Includes four boilerplate apps and five custom apps to configure segment routing SID mappings (IPv4 and IPv6) for XR data model using CRUD/gNMI:
gn-create-xr-segment-routing-ms-cfg-10-ydk.py - create boilerplate
gn-create-xr-segment-routing-ms-cfg-20-ydk.py - IPv4 single mapping
gn-create-xr-segment-routing-ms-cfg-21-ydk.py - IPv6 single mapping
gn-create-xr-segment-routing-ms-cfg-22-ydk.py - IPv4 multiple mappings
gn-create-xr-segment-routing-ms-cfg-23-ydk.py - IPv6 multiple mappings
gn-delete-xr-segment-routing-ms-cfg-10-ydk.py - delete boilerplate
gn-delete-xr-segment-routing-ms-cfg-20-ydk.py - delete all mapping cfg
gn-read-xr-segment-routing-ms-cfg-10-ydk.py   - read boilerplate
gn-update-xr-segment-routing-ms-cfg-10-ydk.py - update boilerplate