### PR TITLE
Add gNMI sample apps to configure OC telemetry

### DIFF
--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-get-oc-telemetry-10-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-get-oc-telemetry-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model openconfig-telemetry.
+
+usage: gn-get-oc-telemetry-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_telemetry_system(telemetry_system):
+    """Process data in telemetry_system object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+
+    # get data from gNMI device
+    # telemetry_system.yfilter = YFilter.read
+    # telemetry_system = gnmi.get(provider, telemetry_system)
+    process_telemetry_system(telemetry_system)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-get-oc-telemetry-20-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-get-oc-telemetry-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model openconfig-telemetry.
+
+usage: gn-get-oc-telemetry-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_telemetry_system(telemetry_system):
+    """Process data in telemetry_system object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+
+    # get data from gNMI device
+    telemetry_system.yfilter = YFilter.read
+    telemetry_system = gnmi.get(provider, telemetry_system)
+    process_telemetry_system(telemetry_system)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-10-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-telemetry.
+
+usage: gn-set-oc-telemetry-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_system(telemetry_system):
+    """Add config data to telemetry_system object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+    config_telemetry_system(telemetry_system)  # add object configuration
+
+    # set configuration on gNMI device
+    # telemetry_system.yfilter = YFilter.replace
+    # gnmi.set(provider, telemetry_system)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.json
@@ -1,0 +1,39 @@
+{
+  "openconfig-telemetry:telemetry-system": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-id": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "persistent": {
+        "subscription": [
+          {
+            "subscription-id": "1",
+            "sensor-profiles": {
+              "sensor-profile": [
+                {
+                  "sensor-group": "SGROUP1",
+                  "config": {
+                    "sensor-group": "SGROUP1",
+                    "sample-interval": "30000"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-telemetry.
+
+usage: gn-set-oc-telemetry-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_system(telemetry_system):
+    """Add config data to telemetry_system object."""
+    #sensor-group
+    sensor_group = telemetry_system.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_id = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_system.sensor_groups.sensor_group.append(sensor_group)
+
+    #subscription
+    subscription = telemetry_system.subscriptions.persistent.Subscription()
+    subscription.subscription_id = 1
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensor_group = "SGROUP1"
+    sensor_profile.config.sensor_group = "SGROUP1"
+    sensor_profile.config.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_system.subscriptions.persistent.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+    config_telemetry_system(telemetry_system)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_system.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_system)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-30-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription 1
+  sensor-group-id SGROUP1 sample-interval 30000
+ !

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.json
@@ -1,0 +1,42 @@
+{
+  "openconfig-telemetry:telemetry-system": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-id": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              },
+              {
+                "path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "persistent": {
+        "subscription": [
+          {
+            "subscription-id": "1",
+            "sensor-profiles": {
+              "sensor-profile": [
+                {
+                  "sensor-group": "SGROUP1",
+                  "config": {
+                    "sensor-group": "SGROUP1",
+                    "sample-interval": "30000"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-telemetry.
+
+usage: gn-set-oc-telemetry-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_system(telemetry_system):
+    """Add config data to telemetry_system object."""
+    #sensor-group
+    sensor_group = telemetry_system.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_id = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_system.sensor_groups.sensor_group.append(sensor_group)
+
+    #subscription
+    subscription = telemetry_system.subscriptions.persistent.Subscription()
+    subscription.subscription_id = 1
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensor_group = "SGROUP1"
+    sensor_profile.config.sensor_group = "SGROUP1"
+    sensor_profile.config.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_system.subscriptions.persistent.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+    config_telemetry_system(telemetry_system)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_system.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_system)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-32-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription 1
+  sensor-group-id SGROUP1 sample-interval 30000
+ !

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.json
@@ -1,0 +1,56 @@
+{
+  "openconfig-telemetry:telemetry-system": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-id": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        },
+        {
+          "sensor-group-id": "SGROUP2",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "persistent": {
+        "subscription": [
+          {
+            "subscription-id": "1",
+            "sensor-profiles": {
+              "sensor-profile": [
+                {
+                  "sensor-group": "SGROUP1",
+                  "config": {
+                    "sensor-group": "SGROUP1",
+                    "sample-interval": "30000"
+                  }
+                },
+                {
+                  "sensor-group": "SGROUP2",
+                  "config": {
+                    "sensor-group": "SGROUP2",
+                    "sample-interval": "8000"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-telemetry.
+
+usage: gn-set-oc-telemetry-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_telemetry \
+    as oc_telemetry
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_system(telemetry_system):
+    """Add config data to telemetry_system object."""
+    #sensor-group
+    sensor_group = telemetry_system.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_id = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_system.sensor_groups.sensor_group.append(sensor_group)
+    sensor_group = telemetry_system.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_id = "SGROUP2"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_system.sensor_groups.sensor_group.append(sensor_group)
+
+    #subscription
+    subscription = telemetry_system.subscriptions.persistent.Subscription()
+    subscription.subscription_id = 1
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensor_group = "SGROUP1"
+    sensor_profile.config.sensor_group = "SGROUP1"
+    sensor_profile.config.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensor_group = "SGROUP2"
+    sensor_profile.config.sensor_group = "SGROUP2"
+    sensor_profile.config.sample_interval = 8000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_system.subscriptions.persistent.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_system = oc_telemetry.TelemetrySystem()  # create object
+    config_telemetry_system(telemetry_system)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_system.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_system)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-telemetry/gn-set-oc-telemetry-34-ydk.txt
@@ -1,0 +1,12 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ sensor-group SGROUP2
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+ !
+ subscription 1
+  sensor-group-id SGROUP1 sample-interval 30000
+  sensor-group-id SGROUP2 sample-interval 8000
+ !


### PR DESCRIPTION
Include two boilerplate apps and four custom apps to configure telemetry using OpenConfig data model, gNMI service and gNMI provider.
gn-get-oc-telemetry-10-ydk.py - get boilerplate
gn-get-oc-telemetry-20-ydk.py - get all telemetry config
gn-set-oc-telemetry-10-ydk.py - set boilerplate
gn-set-oc-telemetry-30-ydk.py - dialin single sensor-group/subscription
gn-set-oc-telemetry-32-ydk.py - dialin multiple sensor-paths
gn-set-oc-telemetry-34-ydk.py - dialin multiple sensor-groups