### PR TITLE
Add gNMI sample app for XR hostname config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: gn-get-xr-shellutil-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_host_names(host_names):
+    """Process data in host_names object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+
+    # get data from gNMI device
+    # host_names.yfilter = YFilter.read
+    # host_names = gnmi.get(provider, host_names)
+    process_host_names(host_names)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: gn-get-xr-shellutil-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_host_names(host_names):
+    """Process data in host_names object."""
+    return "hostname: {}".format(host_names.host_name)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+
+    # get data from gNMI device
+    host_names.yfilter = YFilter.read
+    host_names = gnmi.get(provider, host_names)
+    print(process_host_names(host_names))  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-get-xr-shellutil-cfg-20-ydk.txt
@@ -1,0 +1,1 @@
+hostname: Router

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: gn-set-xr-shellutil-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_host_names(host_names):
+    """Add config data to host_names object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+    config_host_names(host_names)  # add object configuration
+
+    # set configuration on gNMI device
+    # host_names.yfilter = YFilter.replace
+    # gnmi.set(provider, host_names)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.json
@@ -1,0 +1,6 @@
+{
+  "Cisco-IOS-XR-shellutil-cfg:host-names": {
+    "host-name": "Router"
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-shellutil-cfg.
+
+usage: gn-set-xr-shellutil-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_shellutil_cfg \
+    as xr_shellutil_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_host_names(host_names):
+    """Add config data to host_names object."""
+    host_names.host_name = "carreras"
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    host_names = xr_shellutil_cfg.HostNames()  # create object
+    config_host_names(host_names)  # add object configuration
+
+    # set configuration on gNMI device
+    host_names.yfilter = YFilter.replace
+    gnmi.set(provider, host_names)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-shellutil-cfg/gn-set-xr-shellutil-cfg-20-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.1.1
+hostname Router
+end
+


### PR DESCRIPTION
Includes two boilerplate apps and two custom apps to configure the device hostname for XR data model using gNMI/gNMI:
gn-set-xr-shellutil-cfg-10-ydk.py - set boilerplate
gn-set-xr-shellutil-cfg-20-ydk.py - set hostname
gn-get-xr-shellutil-cfg-10-ydk.py - get boilerplate
gn-get-xr-shellutil-cfg-20-ydk.py - get hostname