### PR TITLE
Add sample apps for OC MPLS config

### DIFF
--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-get-oc-mpls-10-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-get-oc-mpls-10-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model openconfig-mpls.
+
+usage: gn-get-oc-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def process_mpls(network_instances):
+    """Add config data to mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+
+    # get data from gNMI device
+    # network_instances.yfilter = YFilter.read
+    # network_instances = gnmi.get(provider, network_instances)
+    process_mpls(network_instances)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-get-oc-mpls-20-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-get-oc-mpls-20-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model openconfig-mpls.
+
+usage: gn-get-oc-mpls-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def process_mpls(network_instances):
+    """Add config data to mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+
+    # get data from gNMI device
+    network_instances.yfilter = YFilter.read
+    network_instances = gnmi.get(provider, network_instances)
+    process_mpls(network_instances)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-10-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-lldp.
+
+usage: gn-set-oc-mpls-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    # network_instances.yfilter = YFilter.replace
+    # gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.json
@@ -1,0 +1,44 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "signaling-protocols": {
+            "rsvp-te": {
+              "interface-attributes": {
+                "interface": [
+                  {
+                    "interface-id": "GigabitEthernet0/0/0/0",
+                    "config": {
+                      "interface-id": "GigabitEthernet0/0/0/0"
+                    },
+                    "subscription": {
+                      "config": {
+                        "subscription": 100
+                      }
+                    }
+                  },
+                  {
+                    "interface-id": "GigabitEthernet0/0/0/1",
+                    "config": {
+                      "interface-id": "GigabitEthernet0/0/0/1"
+                    },
+                    "subscription": {
+                      "config": {
+                        "subscription": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-lldp.
+
+usage: gn-set-oc-mpls-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    """Add config data to mpls object."""
+    rsvp_te = network_instance.mpls.signaling_protocols.rsvp_te
+    interface = rsvp_te.interface_attributes.Interface()
+    interface.interface_id = "GigabitEthernet0/0/0/0"
+    interface.config.interface_id = "GigabitEthernet0/0/0/0"
+    interface.subscription.config.subscription = 100
+    rsvp_te.interface_attributes.interface.append(interface)
+
+    # signaling protocols interface gi0/0/0/1
+    interface = rsvp_te.interface_attributes.Interface()
+    interface.interface_id = "GigabitEthernet0/0/0/1"
+    interface.config.interface_id = "GigabitEthernet0/0/0/1"
+    interface.subscription.config.subscription = 100
+    rsvp_te.interface_attributes.interface.append(interface)
+
+    network_instance.mpls.signaling_protocols.rsvp_te = rsvp_te
+
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-20-ydk.txt
@@ -1,0 +1,14 @@
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth percentage 100
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth percentage 100
+ !
+!
+mpls traffic-eng
+ interface GigabitEthernet0/0/0/0
+ !
+ interface GigabitEthernet0/0/0/1
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.json
@@ -1,0 +1,23 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "te-global-attributes": {
+            "te-lsp-timers": {
+              "config": {
+                "install-delay": 20,
+                "cleanup-delay": 20,
+                "reoptimize-timer": 3600
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # LSP timers
+    network_instance.mpls.te_global_attributes.te_lsp_timers.config.cleanup_delay = 20
+    network_instance.mpls.te_global_attributes.te_lsp_timers.config.install_delay = 20
+    network_instance.mpls.te_global_attributes.te_lsp_timers.config.reoptimize_timer = 3600
+
+    network_instances.network_instance.append(network_instance)
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.update
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-30-ydk.txt
@@ -1,0 +1,5 @@
+mpls traffic-eng
+ reoptimize 3600
+ reoptimize timers delay cleanup 20
+ reoptimize timers delay installation 20
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.json
@@ -1,0 +1,30 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "te-interface-attributes": {
+            "interface": [
+              {
+                "interface-id": "GigabitEthernet0/0/0/0",
+                "config": {
+                  "interface-id": "GigabitEthernet0/0/0/0"
+                }
+              },
+              {
+                "interface-id": "GigabitEthernet0/0/0/1",
+                "config": {
+                  "interface-id": "GigabitEthernet0/0/0/1"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # interface attributes gi0/0/0/0
+    interface = network_instance.mpls.te_interface_attributes.Interface()
+    interface.interface_id = "GigabitEthernet0/0/0/0"
+    interface.config.interface_id = "GigabitEthernet0/0/0/0"
+    network_instance.mpls.te_interface_attributes.interface.append(interface)
+
+    # interface attributes gi0/0/0/1
+    interface = network_instance.mpls.te_interface_attributes.Interface()
+    interface.interface_id = "GigabitEthernet0/0/0/1"
+    interface.config.interface_id = "GigabitEthernet0/0/0/1"
+    network_instance.mpls.te_interface_attributes.interface.append(interface)
+
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-32-ydk.txt
@@ -1,0 +1,12 @@
+srlg
+ interface GigabitEthernet0/0/0/0
+ !
+ interface GigabitEthernet0/0/0/1
+ !
+!
+mpls traffic-eng
+ interface GigabitEthernet0/0/0/0
+ !
+ interface GigabitEthernet0/0/0/1
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.json
@@ -1,0 +1,48 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "te-global-attributes": {
+            "mpls-admin-groups": {
+              "admin-group": [
+                {
+                  "admin-group-name": "RED",
+                  "config": {
+                    "admin-group-name": "RED",
+                    "bit-position": 0
+                  }
+                },
+                {
+                  "admin-group-name": "BLUE",
+                  "config": {
+                    "admin-group-name": "BLUE",
+                    "bit-position": 1
+                  }
+                }
+              ]
+            }
+          },
+          "te-interface-attributes": {
+            "interface": [
+              {
+                "interface-id": "GigabitEthernet0/0/0/1",
+                "config": {
+                  "interface-id": "GigabitEthernet0/0/0/1",
+                  "admin-group": [
+                    "RED",
+                    "BLUE"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+    # interface attributes gi0/0/0/0
+    interface = network_instance.mpls.te_interface_attributes.Interface()
+    interface.interface_id = "GigabitEthernet0/0/0/1"
+    interface.config.interface_id = "GigabitEthernet0/0/0/1"
+    interface.config.admin_group.append("RED")
+    interface.config.admin_group.append("BLUE")
+    network_instance.mpls.te_interface_attributes.interface.append(interface)
+
+    # TE global attributes
+    admin_group = network_instance.mpls.te_global_attributes.mpls_admin_groups.AdminGroup()
+    admin_group.admin_group_name = "RED"
+    admin_group.config.admin_group_name = "RED"
+    admin_group.config.bit_position = 0
+    network_instance.mpls.te_global_attributes.mpls_admin_groups.admin_group.append(admin_group)
+    admin_group = network_instance.mpls.te_global_attributes.mpls_admin_groups.AdminGroup()
+    admin_group.admin_group_name = "BLUE"
+    admin_group.config.admin_group_name = "BLUE"
+    admin_group.config.bit_position = 1
+    network_instance.mpls.te_global_attributes.mpls_admin_groups.admin_group.append(admin_group)
+
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-34-ydk.txt
@@ -1,0 +1,11 @@
+srlg
+ interface GigabitEthernet0/0/0/1
+ !
+!
+mpls traffic-eng
+ interface GigabitEthernet0/0/0/1
+  attribute-names RED BLUE
+ !
+ affinity-map RED bit-position 0
+ affinity-map BLUE bit-position 1
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.json
@@ -1,0 +1,48 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "named-explicit-paths": {
+                "named-explicit-path": [
+                  {
+                    "name": "LER1-LSR1-LER2",
+                    "config": {
+                      "name": "LER1-LSR1-LER2"
+                    },
+                    "explicit-route-objects": {
+                      "explicit-route-object": [
+                        {
+                          "index": 10,
+                          "config": {
+                            "address": "172.16.1.1",
+                            "hop-type": "STRICT",
+                            "index": 10
+                          }
+                        },
+                        {
+                          "index": 20,
+                          "config": {
+                            "address": "172.16.1.5",
+                            "hop-type": "STRICT",
+                            "index": 20
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls \
+    as oc_mpls
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # constrained path
+    named_explicit_path = network_instance.mpls.lsps.constrained_path.named_explicit_paths.NamedExplicitPath()
+    named_explicit_path.name = "LER1-LSR1-LER2"
+    named_explicit_path.config.name = "LER1-LSR1-LER2"
+
+    # strict hop
+    explicit_route_object = named_explicit_path.explicit_route_objects.ExplicitRouteObject()
+    explicit_route_object.index = 10
+    explicit_route_object.config.index = 10
+    explicit_route_object.config.address = "172.16.1.1"
+    explicit_route_object.config.hop_type = oc_mpls.MplsHopType.STRICT
+    named_explicit_path.explicit_route_objects.explicit_route_object.append(explicit_route_object)
+
+    # strict hop
+    explicit_route_object = named_explicit_path.explicit_route_objects.ExplicitRouteObject()
+    explicit_route_object.index = 20
+    explicit_route_object.config.index = 20
+    explicit_route_object.config.address = "172.16.1.5"
+    explicit_route_object.config.hop_type = oc_mpls.MplsHopType.STRICT
+    named_explicit_path.explicit_route_objects.explicit_route_object.append(explicit_route_object)
+    network_instance.mpls.lsps.constrained_path.named_explicit_paths.named_explicit_path.append(named_explicit_path)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-40-ydk.txt
@@ -1,0 +1,6 @@
+explicit-path name LER1-LSR1-LER2
+ index 10 next-address strict ipv4 unicast 172.16.1.1
+ index 20 next-address strict ipv4 unicast 172.16.1.5
+!
+mpls traffic-eng
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.json
@@ -1,0 +1,51 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "tunnels": {
+                "tunnel": [
+                  {
+                    "name": "LER1-LER2-t50",
+                    "config": {
+                      "name": "LER1-LER2-t50",
+                      "type": "openconfig-mpls-types:P2P"
+                    },
+                    "bandwidth": {
+                      "config": {
+                        "set-bandwidth": "100000"
+                      }
+                    },
+                    "p2p-tunnel-attributes": {
+                      "config": {
+                        "destination": "172.16.255.2"
+                      },
+                      "p2p-primary-path": {
+                        "p2p-primary-path": [
+                          {
+                            "name": "DYNAMIC",
+                            "config": {
+                              "name": "DYNAMIC",
+                              "path-computation-method": "openconfig-mpls-types:LOCALLY_COMPUTED",
+                              "preference": 10
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-50-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls_types \
+    as oc_mpls_types
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # dynamic tunnel
+    tunnel = network_instance.mpls.lsps.constrained_path.tunnels.Tunnel()
+    tunnel.name = "LER1-LER2-t50"
+    tunnel.config.name = "LER1-LER2-t50"
+    tunnel.config.type = oc_mpls_types.P2P()
+    #tunnel.type = oc_mpls_types.P2P()
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "DYNAMIC"
+    p2p_primary_path.config.name = "DYNAMIC"
+    p2p_primary_path.config.preference = 10
+    path_computation_method = oc_mpls_types.LOCALLYCOMPUTED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    network_instance.mpls.lsps.constrained_path.tunnels.tunnel.append(tunnel)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script
+

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-50-ydk.txt
@@ -1,0 +1,12 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t50
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+  !
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.json
@@ -1,0 +1,67 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "tunnels": {
+                "tunnel": [
+                  {
+                    "name": "LER1-LER2-t52",
+                    "config": {
+                      "name": "LER1-LER2-t52",
+                      "type": "openconfig-mpls-types:P2P"
+                    },
+                    "bandwidth": {
+                      "auto-bandwidth": {
+                        "config": {
+                          "enabled": true,
+                          "min-bw": "10000",
+                          "max-bw": "500000"
+                        },
+                        "overflow": {
+                          "config": {
+                            "overflow-threshold": 15,
+                            "trigger-event-count": 3
+                          }
+                        },
+                        "underflow": {
+                          "config": {
+                            "underflow-threshold": 15,
+                            "trigger-event-count": 3
+                          }
+                        }
+                      }
+                    },
+                    "p2p-tunnel-attributes": {
+                      "config": {
+                        "destination": "172.16.255.2"
+                      },
+                      "p2p-primary-path": {
+                        "p2p-primary-path": [
+                          {
+                            "name": "DYNAMIC",
+                            "config": {
+                              "name": "DYNAMIC",
+                              "path-computation-method": "openconfig-mpls-types:LOCALLY_COMPUTED",
+                              "preference": 10
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-52-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls_types \
+    as oc_mpls_types
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # auto-bw tunnel
+    tunnel = network_instance.mpls.lsps.constrained_path.tunnels.Tunnel()
+    tunnel.name = "LER1-LER2-t52"
+    tunnel.config.name = "LER1-LER2-t52"
+    tunnel.config.type = oc_mpls_types.P2P()
+    #tunnel.type = oc_mpls_types.P2P()
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "DYNAMIC"
+    p2p_primary_path.config.name = "DYNAMIC"
+    p2p_primary_path.config.preference = 10
+    path_computation_method = oc_mpls_types.LOCALLYCOMPUTED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    # auto-bandwidth configuration
+    tunnel.bandwidth.auto_bandwidth.config.enabled = True
+    tunnel.bandwidth.auto_bandwidth.config.min_bw = 10000
+    tunnel.bandwidth.auto_bandwidth.config.max_bw = 500000
+    tunnel.bandwidth.auto_bandwidth.overflow.config.overflow_threshold = 15
+    tunnel.bandwidth.auto_bandwidth.overflow.config.trigger_event_count = 3
+    tunnel.bandwidth.auto_bandwidth.underflow.config.underflow_threshold = 15
+    tunnel.bandwidth.auto_bandwidth.underflow.config.trigger_event_count = 3
+
+    network_instance.mpls.lsps.constrained_path.tunnels.tunnel.append(tunnel)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-52-ydk.txt
@@ -1,0 +1,16 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t52
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   auto-bw
+    bw-limit min 10000 max 500000
+    overflow threshold 15 min 10 limit 3
+    underflow threshold 15 min 10 limit 3
+   !
+   destination 172.16.255.2
+  !
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.json
@@ -1,0 +1,52 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "tunnels": {
+                "tunnel": [
+                  {
+                    "name": "LER1-LER2-t54",
+                    "config": {
+                      "name": "LER1-LER2-t54",
+                      "type": "openconfig-mpls-types:P2P",
+                      "protection-style-requested": "openconfig-mpls-types:LINK_PROTECTION_REQUIRED"
+                    },
+                    "bandwidth": {
+                      "config": {
+                        "set-bandwidth": "100000"
+                      }
+                    },
+                    "p2p-tunnel-attributes": {
+                      "config": {
+                        "destination": "172.16.255.2"
+                      },
+                      "p2p-primary-path": {
+                        "p2p-primary-path": [
+                          {
+                            "name": "DYNAMIC",
+                            "config": {
+                              "name": "DYNAMIC",
+                              "path-computation-method": "openconfig-mpls-types:LOCALLY_COMPUTED",
+                              "preference": 10
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-54-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls_types \
+    as oc_mpls_types
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # tunnel with protection requested
+    tunnel = network_instance.mpls.lsps.constrained_path.tunnels.Tunnel()
+    tunnel.name = "LER1-LER2-t54"
+    tunnel.config.name = "LER1-LER2-t54"
+    tunnel.config.type = oc_mpls_types.P2P()
+    tunnel.config.protection_style_requested = oc_mpls_types.LINKPROTECTIONREQUIRED()
+    #tunnel.type = oc_mpls_types.P2P()
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "DYNAMIC"
+    p2p_primary_path.config.name = "DYNAMIC"
+    p2p_primary_path.config.preference = 10
+    path_computation_method = oc_mpls_types.LOCALLYCOMPUTED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    network_instance.mpls.lsps.constrained_path.tunnels.tunnel.append(tunnel)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-54-ydk.txt
@@ -1,0 +1,13 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t54
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+   fast-reroute
+  !
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.json
@@ -1,0 +1,60 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "tunnels": {
+                "tunnel": [
+                  {
+                    "name": "LER1-LER2-t56",
+                    "config": {
+                      "name": "LER1-LER2-t56",
+                      "type": "openconfig-mpls-types:P2P",
+                      "setup-priority": 5,
+                      "hold-priority": 5
+                    },
+                    "bandwidth": {
+                      "config": {
+                        "set-bandwidth": "100000"
+                      }
+                    },
+                    "p2p-tunnel-attributes": {
+                      "config": {
+                        "destination": "172.16.255.2"
+                      },
+                      "p2p-primary-path": {
+                        "p2p-primary-path": [
+                          {
+                            "name": "DYNAMIC",
+                            "config": {
+                              "name": "DYNAMIC",
+                              "path-computation-method": "openconfig-mpls-types:LOCALLY_COMPUTED",
+                              "preference": 10
+                            },
+                            "admin-groups": {
+                              "config": {
+                                "exclude-group": [
+                                  "RED"
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-56-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls_types \
+    as oc_mpls_types
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # tunnel with affinity and priority 5/5
+    tunnel = network_instance.mpls.lsps.constrained_path.tunnels.Tunnel()
+    tunnel.name = "LER1-LER2-t56"
+    tunnel.config.name = "LER1-LER2-t56"
+    tunnel.config.setup_priority = 5
+    tunnel.config.hold_priority = 5
+    tunnel.config.type = oc_mpls_types.P2P()
+    #tunnel.type = oc_mpls_types.P2P()
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "DYNAMIC"
+    p2p_primary_path.config.name = "DYNAMIC"
+    p2p_primary_path.config.preference = 10
+    path_computation_method = oc_mpls_types.LOCALLYCOMPUTED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    p2p_primary_path.admin_groups.config.exclude_group.append("RED")
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    network_instance.mpls.lsps.constrained_path.tunnels.tunnel.append(tunnel)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-56-ydk.txt
@@ -1,0 +1,14 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t56
+   path-option DYNAMIC
+    preference 10
+    computation dynamic
+   !
+   priority 5 5
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+   affinity exclude RED
+  !
+ !
+!

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.json
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.json
@@ -1,0 +1,60 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default"
+        },
+        "mpls": {
+          "lsps": {
+            "constrained-path": {
+              "tunnels": {
+                "tunnel": [
+                  {
+                    "name": "LER1-LER2-t58",
+                    "config": {
+                      "name": "LER1-LER2-t58",
+                      "type": "openconfig-mpls-types:P2P"
+                    },
+                    "bandwidth": {
+                      "config": {
+                        "set-bandwidth": "100000"
+                      }
+                    },
+                    "p2p-tunnel-attributes": {
+                      "config": {
+                        "destination": "172.16.255.2"
+                      },
+                      "p2p-primary-path": {
+                        "p2p-primary-path": [
+                          {
+                            "name": "LER1-LSR1-LER2",
+                            "config": {
+                              "name": "LER1-LSR1-LER2",
+                              "path-computation-method": "openconfig-mpls-types:EXPLICITLY_DEFINED",
+                              "explicit-path-name": "LER1-LSR1-LER2",
+                              "preference": 10
+                            }
+                          },
+                          {
+                            "name": "DYNAMIC",
+                            "config": {
+                              "name": "DYNAMIC",
+                              "path-computation-method": "openconfig-mpls-types:LOCALLY_COMPUTED",
+                              "preference": 20
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.py
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model openconfig-mpls.
+
+usage: gn-set-oc-mpls-58-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.openconfig import openconfig_network_instance \
+    as oc_network_instance
+from ydk.models.openconfig import openconfig_mpls_types \
+    as oc_mpls_types
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+
+def config_mpls(network_instances):
+    """Add config data to mpls object."""
+    # configure default network instance
+    network_instance = network_instances.NetworkInstance()
+    network_instance.name = "default"
+    network_instance.config.name = "default"
+
+    # tunnel with explicit and dynamic path options
+    tunnel = network_instance.mpls.lsps.constrained_path.tunnels.Tunnel()
+    tunnel.name = "LER1-LER2-t58"
+    tunnel.config.name = "LER1-LER2-t58"
+    tunnel.config.type = oc_mpls_types.P2P()
+    #tunnel.type = oc_mpls_types.P2P()
+    # explicit path
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "LER1-LSR1-LER2"
+    p2p_primary_path.config.name = "LER1-LSR1-LER2"
+    p2p_primary_path.config.preference = 10
+    p2p_primary_path.config.explicit_path_name = "LER1-LSR1-LER2"
+    path_computation_method = oc_mpls_types.EXPLICITLYDEFINED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    # dynamic path
+    p2p_primary_path = tunnel.p2p_tunnel_attributes.p2p_primary_path.P2pPrimaryPath_()
+    p2p_primary_path.name = "DYNAMIC"
+    p2p_primary_path.config.name = "DYNAMIC"
+    p2p_primary_path.config.preference = 20
+    path_computation_method = oc_mpls_types.LOCALLYCOMPUTED()
+    p2p_primary_path.config.path_computation_method = path_computation_method
+    tunnel.p2p_tunnel_attributes.p2p_primary_path.p2p_primary_path.append(p2p_primary_path)
+    tunnel.p2p_tunnel_attributes.config.destination = "172.16.255.2"
+    tunnel.bandwidth.config.set_bandwidth = 100000
+
+    network_instance.mpls.lsps.constrained_path.tunnels.tunnel.append(tunnel)
+    network_instances.network_instance.append(network_instance)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    network_instances = oc_network_instance.NetworkInstances()
+    config_mpls(network_instances)  # add object configuration
+
+    # set configuration on gNMI device
+    network_instances.yfilter = YFilter.replace
+    gnmi.set(provider, network_instances)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.txt
+++ b/samples/basic/gnmi/models/openconfig/openconfig-mpls/gn-set-oc-mpls-58-ydk.txt
@@ -1,0 +1,16 @@
+mpls traffic-eng
+ named-tunnels
+  tunnel-te LER1-LER2-t58
+   path-option DYNAMIC
+    preference 20
+    computation dynamic
+   !
+   path-option LER1-LSR1-LER2
+    preference 10
+    computation explicit LER1-LSR1-LER2
+   !
+   signalled-bandwidth 100000
+   destination 172.16.255.2
+  !
+ !
+!


### PR DESCRIPTION
Includes two boilerplate apps and eleven custom apps to configure
MPLS using OpenConfig data model, gNMI service and gNMI provider.
gn-set-oc-mpls-10-ydk.py - set boilerplate
gn-set-oc-mpls-20-ydk.py - enable RSVP-TE on interfaces
gn-set-oc-mpls-30-ydk.py - set MPLS-TE timers
gn-set-oc-mpls-32-ydk.py - enable MPLS-TE on interfaces
gn-set-oc-mpls-34-ydk.py - set affinities (admin groups)
gn-set-oc-mpls-40-ydk.py - explicit path
gn-set-oc-mpls-50-ydk.py - dynamic-path tunnel
gn-set-oc-mpls-52-ydk.py - auto-bw tunnel
gn-set-oc-mpls-54-ydk.py - protected tunnel
gn-set-oc-mpls-56-ydk.py - tunnel prio/admin-group
gn-set-oc-mpls-58-ydk.py - tunnel with path options
gn-get-oc-mpls-10-ydk.py - get boilerplate
gn-get-oc-mpls-20-ydk.py - get MPLS