### PR TITLE
Add gNMI sample apps for XR telemetry config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-get-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-get-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-get-xr-telemetry-model-driven-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_telemetry_model_driven(telemetry_model_driven):
+    """Process data in telemetry_model_driven object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+
+    # get data from gNMI device
+    # telemetry_model_driven.yfilter = YFilter.read
+    # telemetry_model_driven = gnmi.get(provider, telemetry_model_driven)
+    process_telemetry_model_driven(telemetry_model_driven)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-get-xr-telemetry-model-driven-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-get-xr-telemetry-model-driven-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-get-xr-telemetry-model-driven-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_telemetry_model_driven(telemetry_model_driven):
+    """Process data in telemetry_model_driven object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+
+    # get data from gNMI device
+    telemetry_model_driven.yfilter = YFilter.read
+    telemetry_model_driven = gnmi.get(provider, telemetry_model_driven)
+    process_telemetry_model_driven(telemetry_model_driven)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    # telemetry_model_driven.yfilter = YFilter.replace
+    # gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.json
@@ -1,0 +1,60 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP1"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "destination-groups": {
+      "destination-group": [
+        {
+          "destination-id": "DGROUP1",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.4",
+                "destination-port": 5432,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "tcp"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # destination group
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP1"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 5432
+    ipv4_destination.ipv4_address = "172.30.8.4"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.tcp
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP1"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-20-ydk.txt
@@ -1,0 +1,17 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ destination-group DGROUP1
+  address family ipv4 172.30.8.4 port 5432
+   encoding self-describing-gpb
+   protocol tcp
+  !
+ !
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+  destination-id DGROUP1
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.json
@@ -1,0 +1,64 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              },
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP1"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "destination-groups": {
+      "destination-group": [
+        {
+          "destination-id": "DGROUP1",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.4",
+                "destination-port": 5432,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "no-tls": [null]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # destination group
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP1"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 5432
+    ipv4_destination.ipv4_address = "172.30.8.4"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.no_tls = Empty()
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP1"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-22-ydk.txt
@@ -1,0 +1,18 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ destination-group DGROUP1
+  address family ipv4 172.30.8.4 port 5432
+   encoding self-describing-gpb
+   protocol grpc no-tls
+  !
+ !
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+  destination-id DGROUP1
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.json
@@ -1,0 +1,75 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        },
+        {
+          "sensor-group-identifier": "SGROUP2",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 5000
+              },
+              {
+                "sensorgroupid": "SGROUP2",
+                "sample-interval": 8000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP1"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "destination-groups": {
+      "destination-group": [
+        {
+          "destination-id": "DGROUP1",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.4",
+                "destination-port": 5432,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "no-tls": [null]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # destination group
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP1"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 5432
+    ipv4_destination.ipv4_address = "172.30.8.4"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.no_tls = Empty()
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP2"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 5000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP2"
+    sensor_profile.sample_interval = 8000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP1"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-24-ydk.txt
@@ -1,0 +1,21 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ destination-group DGROUP1
+  address family ipv4 172.30.8.4 port 5432
+   encoding self-describing-gpb
+   protocol grpc no-tls
+  !
+ !
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ sensor-group SGROUP2
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 5000
+  sensor-group-id SGROUP2 sample-interval 8000
+  destination-id DGROUP1
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.json
@@ -1,0 +1,70 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP1"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "destination-groups": {
+      "destination-group": [
+        {
+          "destination-id": "DGROUP1",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.4",
+                "destination-port": 5432,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "no-tls": [null]
+                }
+              },
+              {
+                "ipv4-address": "172.30.8.11",
+                "destination-port": 9876,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "no-tls": [null]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # destination group
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP1"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 5432
+    ipv4_destination.ipv4_address = "172.30.8.4"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.no_tls = Empty()
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 9876
+    ipv4_destination.ipv4_address = "172.30.8.11"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.no_tls = Empty()
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+ 
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP1"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-26-ydk.txt
@@ -1,0 +1,21 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ destination-group DGROUP1
+  address family ipv4 172.30.8.4 port 5432
+   encoding self-describing-gpb
+   protocol grpc no-tls
+  !
+  address family ipv4 172.30.8.11 port 9876
+   encoding self-describing-gpb
+   protocol grpc no-tls
+  !
+ !
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+  destination-id DGROUP1
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.json
@@ -1,0 +1,105 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        },
+        {
+          "sensor-group-identifier": "SGROUP2",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 5000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP1"
+              }
+            ]
+          }
+        },
+        {
+          "subscription-identifier": "SUB2",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP2",
+                "sample-interval": 8000
+              }
+            ]
+          },
+          "destination-profiles": {
+            "destination-profile": [
+              {
+                "destination-id": "DGROUP2"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "destination-groups": {
+      "destination-group": [
+        {
+          "destination-id": "DGROUP1",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.4",
+                "destination-port": 5432,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "tls-hostname": "TLS_HOSTNAME"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "destination-id": "DGROUP2",
+          "ipv4-destinations": {
+            "ipv4-destination": [
+              {
+                "ipv4-address": "172.30.8.11",
+                "destination-port": 9876,
+                "encoding": "self-describing-gpb",
+                "protocol": {
+                  "protocol": "grpc",
+                  "tls-hostname": "TLS_HOSTNAME"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # destination group
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP1"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 5432
+    ipv4_destination.ipv4_address = "172.30.8.4"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.tls_hostname = "TLS_HOSTNAME"
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+    destination_group = telemetry_model_driven.destination_groups.DestinationGroup()
+    destination_group.destination_id = "DGROUP2"
+    ipv4_destination = destination_group.ipv4_destinations.Ipv4Destination()
+    ipv4_destination.destination_port = 9876
+    ipv4_destination.ipv4_address = "172.30.8.11"
+    ipv4_destination.encoding = xr_telemetry_model_driven_cfg.EncodeType.self_describing_gpb
+    protocol = ipv4_destination.Protocol()
+    protocol.protocol = xr_telemetry_model_driven_cfg.ProtoType.grpc
+    protocol.tls_hostname = "TLS_HOSTNAME"
+    ipv4_destination.protocol = protocol
+    destination_group.ipv4_destinations.ipv4_destination.append(ipv4_destination)
+    telemetry_model_driven.destination_groups.destination_group.append(destination_group)
+
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP2"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+ 
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 5000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP1"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB2"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP2"
+    sensor_profile.sample_interval = 8000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile) 
+    destination_profile = subscription.destination_profiles.DestinationProfile()
+    destination_profile.destination_id = "DGROUP2"
+    subscription.destination_profiles.destination_profile.append(destination_profile) 
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-28-ydk.txt
@@ -1,0 +1,30 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ destination-group DGROUP1
+  address family ipv4 172.30.8.4 port 5432
+   encoding self-describing-gpb
+   protocol grpc tls-hostname TLS_HOSTNAME
+  !
+ !
+ destination-group DGROUP2
+  address family ipv4 172.30.8.11 port 9876
+   encoding self-describing-gpb
+   protocol grpc tls-hostname TLS_HOSTNAME
+  !
+ !
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ sensor-group SGROUP2
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 5000
+  destination-id DGROUP1
+ !
+ subscription SUB2
+  sensor-group-id SGROUP2 sample-interval 8000
+  destination-id DGROUP2
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.json
@@ -1,0 +1,34 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+ 
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-30-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.json
@@ -1,0 +1,37 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              },
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+ 
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-32-ydk.txt
@@ -1,0 +1,11 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.json
@@ -1,0 +1,48 @@
+{
+  "Cisco-IOS-XR-telemetry-model-driven-cfg:telemetry-model-driven": {
+    "sensor-groups": {
+      "sensor-group": [
+        {
+          "sensor-group-identifier": "SGROUP1",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters"
+              }
+            ]
+          }
+        },
+        {
+          "sensor-group-identifier": "SGROUP2",
+          "sensor-paths": {
+            "sensor-path": [
+              {
+                "telemetry-sensor-path": "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subscriptions": {
+      "subscription": [
+        {
+          "subscription-identifier": "SUB1",
+          "sensor-profiles": {
+            "sensor-profile": [
+              {
+                "sensorgroupid": "SGROUP1",
+                "sample-interval": 30000
+              },
+              {
+                "sensorgroupid": "SGROUP2",
+                "sample-interval": 8000
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-telemetry-model-driven-cfg.
+
+usage: gn-set-xr-telemetry-model-driven-cfg-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_telemetry_model_driven_cfg \
+    as xr_telemetry_model_driven_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_telemetry_model_driven(telemetry_model_driven):
+    """Add config data to telemetry_model_driven object."""
+    # sensor group
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP1"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters" 
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+    sensor_group = telemetry_model_driven.sensor_groups.SensorGroup()
+    sensor_group.sensor_group_identifier = "SGROUP2"
+    sensor_path = sensor_group.sensor_paths.SensorPath()
+    sensor_path.telemetry_sensor_path = "Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary"
+    sensor_group.sensor_paths.sensor_path.append(sensor_path)
+    telemetry_model_driven.sensor_groups.sensor_group.append(sensor_group)
+ 
+    # subscription
+    subscription = telemetry_model_driven.subscriptions.Subscription()
+    subscription.subscription_identifier = "SUB1"
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP1"
+    sensor_profile.sample_interval = 30000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    sensor_profile = subscription.sensor_profiles.SensorProfile()
+    sensor_profile.sensorgroupid = "SGROUP2"
+    sensor_profile.sample_interval = 8000
+    subscription.sensor_profiles.sensor_profile.append(sensor_profile)
+    telemetry_model_driven.subscriptions.subscription.append(subscription)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    telemetry_model_driven = xr_telemetry_model_driven_cfg.TelemetryModelDriven()  # create object
+    config_telemetry_model_driven(telemetry_model_driven)  # add object configuration
+
+    # set configuration on gNMI device
+    telemetry_model_driven.yfilter = YFilter.replace
+    gnmi.set(provider, telemetry_model_driven)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-telemetry-model-driven-cfg/gn-set-xr-telemetry-model-driven-cfg-34-ydk.txt
@@ -1,0 +1,14 @@
+!! IOS XR Configuration version = 6.1.2
+telemetry model-driven
+ sensor-group SGROUP1
+  sensor-path Cisco-IOS-XR-infra-statsd-oper:infra-statistics/interfaces/interface/latest/generic-counters
+ !
+ sensor-group SGROUP2
+  sensor-path Cisco-IOS-XR-nto-misc-oper:memory-summary/nodes/node/summary
+ !
+ subscription SUB1
+  sensor-group-id SGROUP1 sample-interval 30000
+  sensor-group-id SGROUP2 sample-interval 8000
+ !
+!
+end


### PR DESCRIPTION
Includes two boilerplate apps and nine custom apps to configure XR telemetry using gNMI/gNMI:
gn-set-xr-telemetry-10-ydk.py - set boilerplate
gn-set-xr-telemetry-20-ydk.py – tcp dialout single sensor-group/subscription
gn-set-xr-telemetry-22-ydk.py – grpc dialout multiple sensor-paths
gn-set-xr-telemetry-24-ydk.py – grpc dialout multiple sensor-groups
gn-set-xr-telemetry-26-ydk.py – grpc dialout multiple destinations
gn-set-xr-telemetry-28-ydk.py – grpc-tls dialout with multiple destination-groups
gn-set-xr-telemetry-30-ydk.py - dialin single sensor-group/subscription
gn-set-xr-telemetry-32-ydk.py - dialin multiple sensor-paths
gn-set-xr-telemetry-34-ydk.py - dialin multiple sensor-groups
gn-get-xr-telemetry-10-ydk.py - get boilerplate
gn-get-xr-telemetry-20-ydk.py - get telemetry