### PR TITLE
Add sample apps for OSPFv3 configuration using gNMI/gNMI

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-get-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-get-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-get-xr-ipv6-ospfv3-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ospfv3(ospfv3):
+    """Process data in ospfv3 object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+
+    # get data from gNMI device
+    # ospfv3.yfilter = YFilter.read
+    # ospfv3 = gnmi.get(provider, ospfv3)
+    process_ospfv3(ospfv3)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-get-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-get-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-get-xr-ipv6-ospfv3-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ospfv3(ospfv3):
+    """Process data in ospfv3 object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+
+    # get data from gNMI device
+    ospfv3.yfilter = YFilter.read
+    ospfv3 = gnmi.get(provider, ospfv3)
+    process_ospfv3(ospfv3)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-set-xr-ipv6-ospfv3-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ospfv3(ospfv3):
+    """Add config data to ospfv3 object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+    config_ospfv3(ospfv3)  # add object configuration
+
+    # set configuration on gNMI device
+    # ospfv3.yfilter = YFilter.replace
+    # gnmi.set(provider, ospfv3)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.json
@@ -1,0 +1,37 @@
+{
+  "Cisco-IOS-XR-ipv6-ospfv3-cfg:ospfv3": {
+    "processes": {
+      "process": [
+        {
+          "process-name": "DEFAULT",
+          "default-vrf": {
+            "router-id": "172.16.255.1",
+            "area-addresses": {
+              "area-area-id": [
+                {
+                  "area-id": 0,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "Loopback0",
+                        "enable": [null],
+                        "passive": true
+                      },
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/0",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-set-xr-ipv6-ospfv3-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ospfv3(ospfv3):
+    """Add config data to ospfv3 object."""
+    # OSPFv3 process
+    process = ospfv3.processes.Process()
+    process.process_name = "DEFAULT"
+    process.default_vrf.router_id = "172.16.255.1"
+
+    # Area 0
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 0
+    area_area_id.enable = Empty()
+
+    # loopback interface passive
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "Loopback0"
+    interface.enable = Empty()
+    interface.passive = True
+    area_area_id.interfaces.interface.append(interface)
+
+    # gi0/0/0/0 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+
+    # append area/process config
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+    ospfv3.processes.process.append(process)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+    config_ospfv3(ospfv3)  # add object configuration
+
+    # set configuration on gNMI device
+    ospfv3.yfilter = YFilter.replace
+    gnmi.set(provider, ospfv3)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-20-ydk.txt
@@ -1,0 +1,14 @@
+!! IOS XR Configuration version = 6.1.1
+router ospfv3 DEFAULT
+ router-id 172.16.255.1
+ area 0
+  interface Loopback0
+   passive
+  !
+  interface GigabitEthernet0/0/0/0
+   network point-to-point
+  !
+ !
+!
+end
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.json
@@ -1,0 +1,50 @@
+{
+  "Cisco-IOS-XR-ipv6-ospfv3-cfg:ospfv3": {
+    "processes": {
+      "process": [
+        {
+          "process-name": "DEFAULT",
+          "default-vrf": {
+            "router-id": "172.16.255.101",
+            "area-addresses": {
+              "area-area-id": [
+                {
+                  "area-id": 0,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "Loopback0",
+                        "enable": [null],
+                        "passive": true
+                      },
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/0",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "area-id": 1,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/1",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-set-xr-ipv6-ospfv3-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ospfv3(ospfv3):
+    """Add config data to ospfv3 object."""
+    # OSPFv3 process
+    process = ospfv3.processes.Process()
+    process.process_name = "DEFAULT"
+    process.default_vrf.router_id = "172.16.255.101"
+
+    # Area 0
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 0
+    area_area_id.enable = Empty()
+
+    # loopback interface passive
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "Loopback0"
+    interface.enable = Empty()
+    interface.passive = True
+    area_area_id.interfaces.interface.append(interface)
+
+    # gi0/0/0/0 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # Area 1
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 1
+    area_area_id.enable = Empty()
+
+    # gi0/0/0/0 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # append process config
+    ospfv3.processes.process.append(process)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+    config_ospfv3(ospfv3)  # add object configuration
+
+    # set configuration on gNMI device
+    ospfv3.yfilter = YFilter.replace
+    gnmi.set(provider, ospfv3)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-30-ydk.txt
@@ -1,0 +1,19 @@
+!! IOS XR Configuration version = 6.1.1
+router ospfv3 DEFAULT
+ router-id 172.16.255.101
+ area 0
+  interface Loopback0
+   passive
+  !
+  interface GigabitEthernet0/0/0/0
+   network point-to-point
+  !
+ !
+ area 1
+  interface GigabitEthernet0/0/0/1
+   network point-to-point
+  !
+ !
+!
+end
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.json
@@ -1,0 +1,51 @@
+{
+  "Cisco-IOS-XR-ipv6-ospfv3-cfg:ospfv3": {
+    "processes": {
+      "process": [
+        {
+          "process-name": "DEFAULT",
+          "default-vrf": {
+            "router-id": "172.16.255.101",
+            "area-addresses": {
+              "area-area-id": [
+                {
+                  "area-id": 0,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "Loopback0",
+                        "enable": [null],
+                        "passive": true
+                      },
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/0",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "area-id": 1,
+                  "stub": false,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/1",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-set-xr-ipv6-ospfv3-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ospfv3(ospfv3):
+    """Add config data to ospfv3 object."""
+    # OSPFv3 process
+    process = ospfv3.processes.Process()
+    process.process_name = "DEFAULT"
+    process.default_vrf.router_id = "172.16.255.101"
+
+    # Area 0
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 0
+    area_area_id.enable = Empty()
+
+    # loopback interface passive
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "Loopback0"
+    interface.enable = Empty()
+    interface.passive = True
+    area_area_id.interfaces.interface.append(interface)
+
+    # gi0/0/0/0 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # Area 1
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 1
+    area_area_id.enable = Empty()
+    area_area_id.stub = False
+
+    # gi0/0/0/1 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # append process config
+    ospfv3.processes.process.append(process)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+    config_ospfv3(ospfv3)  # add object configuration
+
+    # set configuration on gNMI device
+    ospfv3.yfilter = YFilter.replace
+    gnmi.set(provider, ospfv3)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-32-ydk.txt
@@ -1,0 +1,20 @@
+!! IOS XR Configuration version = 6.1.1
+router ospfv3 DEFAULT
+ router-id 172.16.255.101
+ area 0
+  interface Loopback0
+   passive
+  !
+  interface GigabitEthernet0/0/0/0
+   network point-to-point
+  !
+ !
+ area 1
+  stub
+  interface GigabitEthernet0/0/0/1
+   network point-to-point
+  !
+ !
+!
+end
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.json
@@ -1,0 +1,50 @@
+{
+  "Cisco-IOS-XR-ipv6-ospfv3-cfg:ospfv3": {
+    "processes": {
+      "process": [
+        {
+          "process-name": "DEFAULT",
+          "default-vrf": {
+            "router-id": "172.16.255.101",
+            "area-addresses": {
+              "area-area-id": [
+                {
+                  "area-id": 0,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "Loopback0",
+                        "enable": [null],
+                        "passive": false
+                      },
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/0",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "area-id": 1,
+                  "stub": true,
+                  "enable": [null],
+                  "interfaces": {
+                    "interface": [
+                      {
+                        "interface-name": "GigabitEthernet0/0/0/1",
+                        "enable": [null],
+                        "network": "point-to-point"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv6-ospfv3-cfg.
+
+usage: gn-set-xr-ipv6-ospfv3-cfg-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv6_ospfv3_cfg \
+    as xr_ipv6_ospfv3_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ospfv3(ospfv3):
+    """Add config data to ospfv3 object."""
+    # OSPFv3 process
+    process = ospfv3.processes.Process()
+    process.process_name = "DEFAULT"
+    process.default_vrf.router_id = "172.16.255.101"
+
+    # Area 0
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 0
+    area_area_id.enable = Empty()
+
+    # loopback interface passive
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "Loopback0"
+    interface.enable = Empty()
+    interface.passive = False
+    area_area_id.interfaces.interface.append(interface)
+
+    # gi0/0/0/0 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/0"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # Area 1
+    area_area_id = process.default_vrf.area_addresses.AreaAreaId()
+    area_area_id.area_id = 1
+    area_area_id.enable = Empty()
+    area_area_id.stub = True
+
+    # gi0/0/0/1 interface
+    interface = area_area_id.interfaces.Interface()
+    interface.interface_name = "GigabitEthernet0/0/0/1"
+    interface.enable = Empty()
+    interface.network = xr_ipv6_ospfv3_cfg.Ospfv3Network.point_to_point
+    area_area_id.interfaces.interface.append(interface)
+    process.default_vrf.area_addresses.area_area_id.append(area_area_id)
+
+    # append process config
+    ospfv3.processes.process.append(process)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ospfv3 = xr_ipv6_ospfv3_cfg.Ospfv3()  # create object
+    config_ospfv3(ospfv3)  # add object configuration
+
+    # set configuration on gNMI device
+    ospfv3.yfilter = YFilter.replace
+    gnmi.set(provider, ospfv3)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv6-ospfv3-cfg/gn-set-xr-ipv6-ospfv3-cfg-34-ydk.txt
@@ -1,0 +1,20 @@
+!! IOS XR Configuration version = 6.1.1
+router ospfv3 DEFAULT
+ router-id 172.16.255.101
+ area 0
+  interface Loopback0
+   passive disable
+  !
+  interface GigabitEthernet0/0/0/0
+   network point-to-point
+  !
+ !
+ area 1
+  stub no-summary
+  interface GigabitEthernet0/0/0/1
+   network point-to-point
+  !
+ !
+!
+end
+


### PR DESCRIPTION
Includes two boilerplate apps and five custom apps to configure
OSPFv3 for XR data model using gNMI/gNMI:
gn-set-xr-ipv6-ospfv3-cfg-10-ydk.py - set boilerplate
gn-set-xr-ipv6-ospfv3-cfg-20-ydk.py - single-area IPv6 routing
gn-set-xr-ipv6-ospfv3-cfg-30-ydk.py - IPv6 ABR
gn-set-xr-ipv6-ospfv3-cfg-32-ydk.py - IPv6 ABR with stub area
gn-set-xr-ipv6-ospfv3-cfg-34-ydk.py - IPv6 ABR with totally stub area
gn-get-xr-ipv6-ospfv3-cfg-10-ydk.py - get boilerplate
gn-get-xr-ipv6-ospfv3-cfg-20-ydk.py - get OSPFv3 config