### PR TITLE
Add gNMI sample app for XR access lists config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-get-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-get-xr-ipv4-acl-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-get-xr-ipv4-acl-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Process data in ipv4_acl_and_prefix_list object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+
+    # get data from gNMI device
+    # ipv4_acl_and_prefix_list.yfilter = YFilter.read
+    # ipv4_acl_and_prefix_list = gnmi.get(provider, ipv4_acl_and_prefix_list)
+    process_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-get-xr-ipv4-acl-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-get-xr-ipv4-acl-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-get-xr-ipv4-acl-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Process data in ipv4_acl_and_prefix_list object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+
+    # get data from gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.read
+    ipv4_acl_and_prefix_list = gnmi.get(provider, ipv4_acl_and_prefix_list)
+    process_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    # ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    # gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.json
@@ -1,0 +1,8 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "log-update": {
+      "rate": 10
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    ipv4_acl_and_prefix_list.log_update.rate = 10
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 access-list log-update rate 10
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "log-update": {
+      "threshold": 5,
+      "rate": 10
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    ipv4_acl_and_prefix_list.log_update.rate = 10
+    ipv4_acl_and_prefix_list.log_update.threshold = 5
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-22-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 access-list log-update rate 10
+ipv4 access-list log-update threshold 5
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.json
@@ -1,0 +1,32 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "accesses": {
+      "access": [
+        {
+          "access-list-name": "ACL1",
+          "access-list-entries": {
+            "access-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "allow one host"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "permit",
+                "source-network": {
+                  "source-address": "172.31.255.1",
+                  "source-wild-card-bits": "0.0.0.0"
+                }
+              },
+              {
+                "sequence-number": 30,
+                "grant": "deny"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    access = ipv4_acl_and_prefix_list.accesses.Access()
+    access.access_list_name = "ACL1"
+    access.access_list_entries = access.AccessListEntries()
+
+    # access-list with sequence number 10
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 10
+    access_list_entry.remark = "allow one host"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 20
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 20
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    access_list_entry.source_network.source_address = "172.31.255.1"
+    access_list_entry.source_network.source_wild_card_bits = "0.0.0.0" 
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    
+    # access-list with sequence number 30
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 30
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    ipv4_acl_and_prefix_list.accesses.access.append(access) 
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-30-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 access-list ACL1
+ 10 remark allow one host
+ 20 permit ipv4 host 172.31.255.1 any
+ 30 deny ipv4 any any
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.json
@@ -1,0 +1,48 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "accesses": {
+      "access": [
+        {
+          "access-list-name": "ACL2",
+          "access-list-entries": {
+            "access-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "allow multiple hosts"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "permit",
+                "source-network": {
+                  "source-address": "172.31.255.1",
+                  "source-wild-card-bits": "0.0.0.0"
+                }
+              },
+              {
+                "sequence-number": 30,
+                "grant": "permit",
+                "source-network": {
+                  "source-address": "172.31.255.33",
+                  "source-wild-card-bits": "0.0.0.0"
+                }
+              },
+              {
+                "sequence-number": 40,
+                "grant": "permit",
+                "source-network": {
+                  "source-address": "172.31.255.65",
+                  "source-wild-card-bits": "0.0.0.0"
+                }
+              },
+              {
+                "sequence-number": 50,
+                "grant": "deny"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    access = ipv4_acl_and_prefix_list.accesses.Access()
+    access.access_list_name = "ACL2"
+    access.access_list_entries = access.AccessListEntries()
+
+    # access-list with sequence number 10
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 10
+    access_list_entry.remark = "allow multiple hosts"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 20
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 20
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    access_list_entry.source_network.source_address = "172.31.255.1"
+    access_list_entry.source_network.source_wild_card_bits = "0.0.0.0"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    
+    # access-list with sequence number 30
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 30
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    access_list_entry.source_network.source_address = "172.31.255.33"
+    access_list_entry.source_network.source_wild_card_bits = "0.0.0.0"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 40
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 40
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    access_list_entry.source_network.source_address = "172.31.255.65"
+    access_list_entry.source_network.source_wild_card_bits = "0.0.0.0"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 50
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 50
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    ipv4_acl_and_prefix_list.accesses.access.append(access) 
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-32-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 access-list ACL2
+ 10 remark allow multiple hosts
+ 20 permit ipv4 host 172.31.255.1 any
+ 30 permit ipv4 host 172.31.255.33 any
+ 40 permit ipv4 host 172.31.255.65 any
+ 50 deny ipv4 any any
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.json
@@ -1,0 +1,67 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "accesses": {
+      "access": [
+        {
+          "access-list-name": "ACL3",
+          "access-list-entries": {
+            "access-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "log access attempts"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "deny",
+                "log-option": "log-input",
+                "source-network": {
+                  "source-address": "173.31.1.0",
+                  "source-prefix-length": 24
+                },
+                "destination-network": {
+                  "destination-address": "172.16.0.0",
+                  "destination-prefix-length": 16
+                }
+              },
+              {
+                "sequence-number": 30,
+                "grant": "deny",
+                "log-option": "log-input",
+                "source-network": {
+                  "source-address": "172.31.2.0",
+                  "source-prefix-length": 24
+                },
+                "destination-network": {
+                  "destination-address": "172.16.0.0",
+                  "destination-prefix-length": 16
+                },
+                "dscp": {
+                  "dscp-min": "ef"
+                }
+              },
+              {
+                "sequence-number": 40,
+                "grant": "deny",
+                "counter-name": "ACL3-COUNTER",
+                "log-option": "log-input",
+                "source-network": {
+                  "source-address": "172.31.3.0",
+                  "source-prefix-length": 24
+                },
+                "destination-network": {
+                  "destination-address": "172.16.0.0",
+                  "destination-prefix-length": 16
+                }
+              },
+              {
+                "sequence-number": 50,
+                "grant": "permit"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    access = ipv4_acl_and_prefix_list.accesses.Access()
+    access.access_list_name = "ACL3"
+    access.access_list_entries = access.AccessListEntries()
+
+    # access-list with sequence number 10
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 10
+    access_list_entry.remark = "log access attempts"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 20
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 20
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    access_list_entry.source_network.source_address = "173.31.1.0"
+    access_list_entry.source_network.source_prefix_length = 24
+    access_list_entry.destination_network.destination_address = "172.16.0.0"
+    access_list_entry.destination_network.destination_prefix_length = 16
+    access_list_entry.log_option = xr_ipv4_acl_datatypes.Ipv4AclLoggingEnum.log_input
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    
+    # access-list with sequence number 30
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 30
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    access_list_entry.source_network.source_address = "172.31.2.0"
+    access_list_entry.source_network.source_prefix_length = 24
+    access_list_entry.destination_network.destination_address= "172.16.0.0"
+    access_list_entry.destination_network.destination_prefix_length = 16
+    access_list_entry.log_option = xr_ipv4_acl_datatypes.Ipv4AclLoggingEnum.log_input
+    access_list_entry.dscp.dscp_min = xr_ipv4_acl_datatypes.Ipv4AclDscpNumber.ef
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 40
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 40
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    access_list_entry.source_network.source_address = "172.31.3.0"
+    access_list_entry.source_network.source_prefix_length = 24
+    access_list_entry.destination_network.destination_address = "172.16.0.0"
+    access_list_entry.destination_network.destination_prefix_length = 16
+    access_list_entry.log_option = xr_ipv4_acl_datatypes.Ipv4AclLoggingEnum.log_input
+    access_list_entry.counter_name = "ACL3-COUNTER"
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+
+    # access-list with sequence number 50
+    access_list_entry = access.access_list_entries.AccessListEntry()
+    access_list_entry.sequence_number = 50
+    access_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    access.access_list_entries.access_list_entry.append(access_list_entry)
+    ipv4_acl_and_prefix_list.accesses.access.append(access) 
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-34-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 access-list ACL3
+ 10 remark log access attempts
+ 20 deny ipv4 172.31.1.0/24 172.16.0.0/16 log-input
+ 30 deny ipv4 172.31.2.0/24 172.16.0.0/16 dscp ef log-input
+ 40 deny ipv4 172.31.3.0/24 172.16.0.0/16 log-input counter ACL3-COUNTER
+ 50 permit ipv4 any any
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.json
@@ -1,0 +1,26 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "prefixes": {
+      "prefix": [
+        {
+          "prefix-list-name": "PREFIX-LIST1",
+          "prefix-list-entries": {
+            "prefix-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "allow single prefix"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "permit",
+                "prefix": "172.16.0.0",
+                "netmask": "255.255.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-80-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    prefix = ipv4_acl_and_prefix_list.prefixes.Prefix()
+    prefix.prefix_list_name = "PREFIX-LIST1"
+    prefix.prefix_list_entries = prefix.PrefixListEntries()
+
+    # prefix list with sequence number 10
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 10
+    prefix_list_entry.remark = "allow single prefix"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    
+    # prefix list with sequence number 20
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 20
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.0.0"
+    prefix_list_entry.prefix = "172.16.0.0"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    ipv4_acl_and_prefix_list.prefixes.prefix.append(prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-80-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 prefix-list PREFIX-LIST1
+ 10 remark allow single prefix
+ 20 permit 172.16.0.0/16
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.json
@@ -1,0 +1,32 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "prefixes": {
+      "prefix": [
+        {
+          "prefix-list-name": "PREFIX-LIST2",
+          "prefix-list-entries": {
+            "prefix-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "allow multiple prefixes"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "permit",
+                "prefix": "172.16.0.0",
+                "netmask": "255.255.0.0"
+              },
+              {
+                "sequence-number": 30,
+                "grant": "permit",
+                "prefix": "172.17.128.0",
+                "netmask": "255.255.255.0"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-82-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    prefix = ipv4_acl_and_prefix_list.prefixes.Prefix()
+    prefix.prefix_list_name = "PREFIX-LIST2"
+    prefix.prefix_list_entries = prefix.PrefixListEntries()
+
+    # prefix list with sequence number 10
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 10
+    prefix_list_entry.remark = "allow multiple prefixes"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    
+    # prefix list with sequence number 20
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 20
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.0.0"
+    prefix_list_entry.prefix = "172.16.0.0"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+
+    # prefix list with sequence number 30
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 30
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.255.0"
+    prefix_list_entry.prefix = "172.17.128.0"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    ipv4_acl_and_prefix_list.prefixes.prefix.append(prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-82-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 prefix-list PREFIX-LIST2
+ 10 remark allow multiple prefixes
+ 20 permit 172.16.0.0/16
+ 30 permit 172.17.128.0/24
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.json
@@ -1,0 +1,34 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "prefixes": {
+      "prefix": [
+        {
+          "prefix-list-name": "PREFIX-LIST3",
+          "prefix-list-entries": {
+            "prefix-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "block a prefix"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "deny",
+                "prefix": "172.31.0.0",
+                "netmask": "255.255.255.0"
+              },
+              {
+                "sequence-number": 30,
+                "grant": "permit",
+                "prefix": "0.0.0.0",
+                "netmask": "0.0.0.0",
+                "match-max-length": [null],
+                "max-prefix-length": 32
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-84-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    prefix = ipv4_acl_and_prefix_list.prefixes.Prefix()
+    prefix.prefix_list_name = "PREFIX-LIST3"
+    prefix.prefix_list_entries = prefix.PrefixListEntries()
+
+    # prefix list with sequence number 10
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 10
+    prefix_list_entry.remark = "block a prefix"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    
+    # prefix list with sequence number 20
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 20
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.deny
+    prefix_list_entry.netmask = "255.255.255.0"
+    prefix_list_entry.prefix = "172.31.0.0"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+
+    # prefix list with sequence number 30
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 30
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "0.0.0.0"
+    prefix_list_entry.prefix = "0.0.0.0"
+    prefix_list_entry.max_prefix_length = 32
+    prefix_list_entry.match_max_length = Empty()
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    ipv4_acl_and_prefix_list.prefixes.prefix.append(prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-84-ydk.txt
@@ -1,0 +1,7 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 prefix-list PREFIX-LIST3
+ 10 remark block a prefix
+ 20 deny 172.31.0.0/24
+ 30 permit 0.0.0.0/0 le 32
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.json
@@ -1,0 +1,46 @@
+{
+  "Cisco-IOS-XR-ipv4-acl-cfg:ipv4-acl-and-prefix-list": {
+    "prefixes": {
+      "prefix": [
+        {
+          "prefix-list-name": "PREFIX-LIST4",
+          "prefix-list-entries": {
+            "prefix-list-entry": [
+              {
+                "sequence-number": 10,
+                "remark": "allow prefix ranges"
+              },
+              {
+                "sequence-number": 20,
+                "grant": "permit",
+                "prefix": "172.17.0.0",
+                "netmask": "255.255.0.0",
+                "match-min-length": [null],
+                "min-prefix-length": 24
+              },
+              {
+                "sequence-number": 30,
+                "grant": "permit",
+                "prefix": "172.18.0.0",
+                "netmask": "255.255.0.0",
+                "match-max-length": [null],
+                "max-prefix-length": 24
+              },
+              {
+                "sequence-number": 40,
+                "grant": "permit",
+                "prefix": "172.19.0.0",
+                "netmask": "255.255.0.0",
+                "match-max-length": [null],
+                "max-prefix-length": 20,
+                "match-min-length": [null],
+                "min-prefix-length": 28
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-acl-cfg.
+
+usage: gn-set-xr-ipv4-acl-cfg-86-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_cfg \
+    as xr_ipv4_acl_cfg
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_acl_datatypes \
+    as xr_ipv4_acl_datatypes
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list):
+    """Add config data to ipv4_acl_and_prefix_list object."""
+    prefix = ipv4_acl_and_prefix_list.prefixes.Prefix()
+    prefix.prefix_list_name = "PREFIX-LIST4"
+    prefix.prefix_list_entries = prefix.PrefixListEntries()
+
+    # prefix list with sequence number 10
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 10
+    prefix_list_entry.remark = "allow prefix ranges"
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    
+    # prefix list with sequence number 20
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 20
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.0.0" 
+    prefix_list_entry.prefix = "172.17.0.0"
+    prefix_list_entry.min_prefix_length = 24
+    prefix_list_entry.match_min_length = Empty()
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+
+    # prefix list with sequence number 30
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 30
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.0.0" 
+    prefix_list_entry.prefix = "172.18.0.0"
+    prefix_list_entry.max_prefix_length = 24
+    prefix_list_entry.match_max_length = Empty()
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+
+    # prefix list with sequence number 40
+    prefix_list_entry = prefix.prefix_list_entries.PrefixListEntry()
+    prefix_list_entry.sequence_number = 40
+    prefix_list_entry.grant = xr_ipv4_acl_datatypes.Ipv4AclGrantEnum.permit
+    prefix_list_entry.netmask = "255.255.0.0" 
+    prefix_list_entry.prefix = "172.19.0.0"
+    prefix_list_entry.max_prefix_length = 20
+    prefix_list_entry.match_max_length = Empty()
+    prefix_list_entry.min_prefix_length = 28
+    prefix_list_entry.match_min_length = Empty()
+    prefix.prefix_list_entries.prefix_list_entry.append(prefix_list_entry)
+    ipv4_acl_and_prefix_list.prefixes.prefix.append(prefix)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    ipv4_acl_and_prefix_list = xr_ipv4_acl_cfg.Ipv4AclAndPrefixList()  # create object
+    config_ipv4_acl_and_prefix_list(ipv4_acl_and_prefix_list)  # add object configuration
+
+    # set configuration on gNMI device
+    ipv4_acl_and_prefix_list.yfilter = YFilter.replace
+    gnmi.set(provider, ipv4_acl_and_prefix_list)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-acl-cfg/gn-set-xr-ipv4-acl-cfg-86-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.2.1
+ipv4 prefix-list PREFIX-LIST4
+ 10 remark allow prefix ranges
+ 20 permit 172.17.0.0/16 ge 24
+ 30 permit 172.18.0.0/16 le 24
+ 40 permit 172.19.0.0/16 ge 28 le 20
+!
+end


### PR DESCRIPTION
Includes two boilerplate apps and ten custom apps to configure
access lists for XR data model using gNMI/gNMI:
gn-set-xr-ipv4-acl-cfg-10-ydk.py - set boilerplate
gn-set-xr-ipv4-acl-cfg-20-ydk.py - Set log-update rate
gn-set-xr-ipv4-acl-cfg-22-ydk.py - Set log-update rate & threshold
gn-set-xr-ipv4-acl-cfg-30-ydk.py - Allow one host
gn-set-xr-ipv4-acl-cfg-32-ydk.py - Allow multiple hosts
gn-set-xr-ipv4-acl-cfg-34-ydk.py - Log access attempts
gn-set-xr-ipv4-acl-cfg-80-ydk.py - Allow single prefix
gn-set-xr-ipv4-acl-cfg-82-ydk.py - Allow multiple prefixes
gn-set-xr-ipv4-acl-cfg-84-ydk.py - Block a prefix
gn-set-xr-ipv4-acl-cfg-86-ydk.py - Allow prefix ranges
gn-get-xr-ipv4-acl-cfg-10-ydk.py - get boilerplate
gn-get-xr-ipv4-acl-cfg-20-ydk.py - get all access lists