### PR TITLE
Add gNMI sample app for XR ARP config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-get-xr-ipv4-arp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_arp(arp):
+    """Process data in arp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+
+    # get data from gNMI device
+    # arp.yfilter = YFilter.read
+    # arp = gnmi.get(provider, arp)
+    process_arp(arp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-11-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-get-xr-ipv4-arp-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_arpgmp(arpgmp):
+    """Process data in arpgmp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+
+    # get data from gNMI device
+    # arpgmp.yfilter = YFilter.read
+    # arpgmp = gnmi.get(provider, arpgmp)
+    process_arpgmp(arpgmp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-12-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-get-xr-ipv4-arp-cfg-12-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_arp_redundancy(arp_redundancy):
+    """Process data in arp_redundancy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp_redundancy = xr_ipv4_arp_cfg.ArpRedundancy()  # create object
+
+    # get data from gNMI device
+    # arp_redundancy.yfilter = YFilter.read
+    # arp_redundancy = gnmi.get(provider, arp_redundancy)
+    process_arp_redundancy(arp_redundancy)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-get-xr-ipv4-arp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_arp(arp):
+    """Process data in arp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+
+    # get data from gNMI device
+    arp.yfilter = YFilter.read
+    arp = gnmi.get(provider, arp)
+    process_arp(arp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-21-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-get-xr-ipv4-arp-cfg-21-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-get-xr-ipv4-arp-cfg-21-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_arpgmp(arpgmp):
+    """Process data in arpgmp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+
+    # get data from gNMI device
+    arpgmp.yfilter = YFilter.read
+    arpgmp = gnmi.get(provider, arpgmp)
+    process_arpgmp(arpgmp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arp(arp):
+    """Add config data to arp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+    config_arp(arp)  # add object configuration
+
+    # set configuration on gNMI device
+    # arp.yfilter = YFilter.replace
+    # gnmi.set(provider, arp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-11-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-11-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # set configuration on gNMI device
+    # arpgmp.yfilter = YFilter.replace
+    # gnmi.set(provider, arpgmp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-12-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-12-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-12-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arp_redundancy(arp_redundancy):
+    """Add config data to arp_redundancy object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp_redundancy = xr_ipv4_arp_cfg.ArpRedundancy()  # create object
+    config_arp_redundancy(arp_redundancy)  # add object configuration
+
+    # set configuration on gNMI device
+    # arp_redundancy.yfilter = YFilter.replace
+    # gnmi.set(provider, arp_redundancy)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.json
@@ -1,0 +1,6 @@
+{
+  "Cisco-IOS-XR-ipv4-arp-cfg:arp": {
+    "outer-cos": 5
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arp(arp):
+    """Add config data to arp object."""
+    arp.outer_cos = 5
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+    config_arp(arp)  # add object configuration
+
+    # set configuration on gNMI device
+    arp.yfilter = YFilter.replace
+    gnmi.set(provider, arp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-20-ydk.txt
@@ -1,0 +1,2 @@
+arp outer-cos 5
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.json
@@ -1,0 +1,8 @@
+{
+  "Cisco-IOS-XR-ipv4-arp-cfg:arp": {
+    "max-entries": 1000,
+    "inner-cos": 4,
+    "outer-cos": 5
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arp(arp):
+    """Add config data to arp object."""
+    arp.inner_cos = 4
+    arp.outer_cos = 5
+    arp.max_entries = 1000
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arp = xr_ipv4_arp_cfg.Arp()  # create object
+    config_arp(arp)  # add object configuration
+
+    # set configuration on gNMI device
+    arp.yfilter = YFilter.replace
+    gnmi.set(provider, arp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-22-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+arp inner-cos 4
+arp outer-cos 5
+arp max-entries 1000
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.json
@@ -1,0 +1,20 @@
+{
+  "Cisco-IOS-XR-ipv4-arp-cfg:arpgmp": {
+    "vrf": [
+      {
+        "vrf-name": "default",
+        "entries": {
+          "entry": [
+            {
+              "address": "172.16.0.1",
+              "mac-address": "52:54:00:28:89:88",
+              "encapsulation": "arpa",
+              "entry-type": "static"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "default"
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncap.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntry.static
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # set configuration on gNMI device
+    arpgmp.yfilter = YFilter.replace
+    gnmi.set(provider, arpgmp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-30-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf default 172.16.0.1 5254.0028.8988 ARPA
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.json
@@ -1,0 +1,26 @@
+{
+  "Cisco-IOS-XR-ipv4-arp-cfg:arpgmp": {
+    "vrf": [
+      {
+        "vrf-name": "default",
+        "entries": {
+          "entry": [
+            {
+              "address": "172.16.0.1",
+              "mac-address": "52:54:00:28:89:88",
+              "encapsulation": "arpa",
+              "entry-type": "static"
+            },
+            {
+              "address": "172.16.0.4",
+              "mac-address": "52:54:00:7d:8f:8f",
+              "encapsulation": "arpa",
+              "entry-type": "static"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "default"
+
+    # arp entry for 172.16.0.1
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncap.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntry.static
+    vrf.entries.entry.append(entry)
+
+    # arp entry for 172.16.0.4
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.4"
+    entry.mac_address = "52:54:00:7d:8f:8f"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncap.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntry.static
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # set configuration on gNMI device
+    arpgmp.yfilter = YFilter.replace
+    gnmi.set(provider, arpgmp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-32-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf default 172.16.0.1 5254.0028.8988 ARPA
+arp vrf default 172.16.0.4 5254.007d.8f8f ARPA
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.json
@@ -1,0 +1,28 @@
+{
+  "Cisco-IOS-XR-ipv4-arp-cfg:arpgmp": {
+    "vrf": [
+      {
+        "vrf-name": "RED",
+        "entries": {
+          "entry": [
+            {
+              "address": "172.16.0.1",
+              "mac-address": "52:54:00:28:89:88",
+              "encapsulation": "arpa",
+              "entry-type": "static",
+              "interface": "GigabitEthernet0/0/0/0"
+            },
+            {
+              "address": "172.16.0.4",
+              "mac-address": "52:54:00:7d:8f:8f",
+              "encapsulation": "arpa",
+              "entry-type": "static",
+              "interface": "GigabitEthernet0/0/0/1"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ipv4-arp-cfg.
+
+usage: gn-set-xr-ipv4-arp-cfg-34-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ipv4_arp_cfg \
+    as xr_ipv4_arp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_arpgmp(arpgmp):
+    """Add config data to arpgmp object."""
+    vrf = arpgmp.Vrf()
+    vrf.vrf_name = "RED"
+
+    # arp entry for 172.16.0.1
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.1"
+    entry.mac_address = "52:54:00:28:89:88"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncap.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntry.static
+    entry.interface = "GigabitEthernet0/0/0/0"
+    vrf.entries.entry.append(entry)
+
+    # arp entry for 172.16.0.4
+    entry = vrf.entries.Entry()
+    entry.address = "172.16.0.4"
+    entry.mac_address = "52:54:00:7d:8f:8f"
+    entry.encapsulation = xr_ipv4_arp_cfg.ArpEncap.arpa
+    entry.entry_type = xr_ipv4_arp_cfg.ArpEntry.static
+    entry.interface = "GigabitEthernet0/0/0/1"
+    vrf.entries.entry.append(entry)
+    arpgmp.vrf.append(vrf)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    arpgmp = xr_ipv4_arp_cfg.Arpgmp()  # create object
+    config_arpgmp(arpgmp)  # add object configuration
+
+    # set configuration on gNMI device
+    arpgmp.yfilter = YFilter.replace
+    gnmi.set(provider, arpgmp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ipv4-arp-cfg/gn-set-xr-ipv4-arp-cfg-34-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+arp vrf RED 172.16.0.1 5254.0028.8988 ARPA interface GigabitEthernet0/0/0/0
+arp vrf RED 172.16.0.4 5254.007d.8f8f ARPA interface GigabitEthernet0/0/0/1
+end
+


### PR DESCRIPTION
Includes six boilerplate apps and seven custom apps to configure the address resolution protocol for XR data model using gNMI/gNMI:
gn-set-xr-ipv4-arp-cfg-10-ydk.py - set boilerplate
gn-set-xr-ipv4-arp-cfg-11-ydk.py - set boilerplate
gn-set-xr-ipv4-arp-cfg-12-ydk.py - set boilerplate
gn-set-xr-ipv4-arp-cfg-20-ydk.py - Global with cos
gn-set-xr-ipv4-arp-cfg-22-ydk.py - Global with cos and max entries
gn-set-xr-ipv4-arp-cfg-30-ydk.py - Single static arp entry
gn-set-xr-ipv4-arp-cfg-32-ydk.py - Multiple static arp entries
gn-set-xr-ipv4-arp-cfg-34-ydk.py - Multiple static arp entries w/vrf
gn-get-xr-ipv4-arp-cfg-10-ydk.py - get boilerplate
gn-get-xr-ipv4-arp-cfg-11-ydk.py - get boilerplate
gn-get-xr-ipv4-arp-cfg-12-ydk.py - get boilerplate
gn-get-xr-ipv4-arp-cfg-20-ydk.py - get arp
gn-get-xr-ipv4-arp-cfg-21-ydk.py - get arp gmp