### PR TITLE
Add gNMI sample app for XR syslog config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-get-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_syslog_service(syslog_service):
+    """Process data in syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+
+    # get data from gNMI device
+    # syslog_service.yfilter = YFilter.read
+    # syslog_service = gnmi.get(provider, syslog_service)
+    process_syslog_service(syslog_service)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-get-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_syslog(syslog):
+    """Process data in syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+
+    # get data from gNMI device
+    # syslog.yfilter = YFilter.read
+    # syslog = gnmi.get(provider, syslog)
+    process_syslog(syslog)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-get-xr-infra-syslog-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_syslog_service(syslog_service):
+    """Process data in syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+
+    # get data from gNMI device
+    syslog_service.yfilter = YFilter.read
+    syslog_service = gnmi.get(provider, syslog_service)
+    process_syslog_service(syslog_service)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-21-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-get-xr-infra-syslog-cfg-21-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-get-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_syslog(syslog):
+    """Process data in syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+
+    # get data from gNMI device
+    syslog.yfilter = YFilter.read
+    syslog = gnmi.get(provider, syslog)
+    process_syslog(syslog)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    # syslog_service.yfilter = YFilter.replace
+    # gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-11-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-11-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-11-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    # syslog.yfilter = YFilter.replace
+    # gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.json
@@ -1,0 +1,10 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog-service": {
+    "timestamps": {
+      "log": {
+        "log-timestamp-disable": [null]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_timestamp_disable = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog_service.yfilter = YFilter.replace
+    gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log disable
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.json
@@ -1,0 +1,10 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog-service": {
+    "timestamps": {
+      "log": {
+        "log-uptime": [null]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_uptime = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog_service.yfilter = YFilter.replace
+    gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-22-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log uptime
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.json
@@ -1,0 +1,14 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog-service": {
+    "timestamps": {
+      "log": {
+        "log-datetime": {
+          "log-datetime-value": {
+            "time-stamp-value": "enable"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfo.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog_service.yfilter = YFilter.replace
+    gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-24-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime 
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.json
@@ -1,0 +1,23 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog-service": {
+    "timestamps": {
+      "log": {
+        "log-datetime": {
+          "log-datetime-value": {
+            "time-stamp-value": "enable",
+            "msec": "enable"
+          }
+        }
+      },
+      "debug": {
+        "debug-datetime": {
+          "datetime-value": {
+            "time-stamp-value": "enable",
+            "msec": "enable"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfo.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfo.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog_service.yfilter = YFilter.replace
+    gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-26-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime msec
+service timestamps debug datetime localtime msec
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.json
@@ -1,0 +1,27 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog-service": {
+    "timestamps": {
+      "log": {
+        "log-datetime": {
+          "log-datetime-value": {
+            "time-stamp-value": "enable",
+            "msec": "enable",
+            "time-zone": "enable",
+            "year": "enable"
+          }
+        }
+      },
+      "debug": {
+        "debug-datetime": {
+          "datetime-value": {
+            "time-stamp-value": "enable",
+            "msec": "enable",
+            "time-zone": "enable",
+            "year": "enable"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog_service(syslog_service):
+    """Add config data to syslog_service object."""
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.msec = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.log.log_datetime.log_datetime_value.year = xr_infra_syslog_cfg.TimeInfo.enable
+
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.msec = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_stamp_value = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.time_zone = xr_infra_syslog_cfg.TimeInfo.enable
+    syslog_service.timestamps.debug.debug_datetime.datetime_value.year = xr_infra_syslog_cfg.TimeInfo.enable
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog_service = xr_infra_syslog_cfg.SyslogService()  # create object
+    config_syslog_service(syslog_service)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog_service.yfilter = YFilter.replace
+    gnmi.set(provider, syslog_service)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-28-ydk.txt
@@ -1,0 +1,4 @@
+!! IOS XR Configuration version = 6.2.1
+service timestamps log datetime localtime msec show-timezone year
+service timestamps debug datetime localtime msec show-timezone year
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.json
@@ -1,0 +1,8 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "console-logging": {
+      "logging-level": "disable"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-30-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.console_logging.logging_level = xr_infra_syslog_cfg.LoggingLevels.disable
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-30-ydk.txt
@@ -1,0 +1,3 @@
+!! IOS XR Configuration version = 6.2.1
+logging console disable
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.json
@@ -1,0 +1,15 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "monitor-logging": {
+      "logging-level": "disable"
+    },
+    "buffered-logging": {
+      "logging-level": "info",
+      "buffer-size": 125000000
+    },
+    "console-logging": {
+      "logging-level": "disable"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-32-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.console_logging.logging_level = xr_infra_syslog_cfg.LoggingLevels.disable
+    syslog.monitor_logging.logging_level = xr_infra_syslog_cfg.LoggingLevels.disable
+    syslog.buffered_logging.buffer_size = 125000000
+    syslog.buffered_logging.logging_level = xr_infra_syslog_cfg.LoggingLevels.info
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-32-ydk.txt
@@ -1,0 +1,6 @@
+!! IOS XR Configuration version = 6.2.1
+logging console disable
+logging monitor disable
+logging buffered 125000000
+logging buffered informational
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.json
@@ -1,0 +1,11 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "archive": {
+      "size": 32,
+      "device": "/disk0:",
+      "frequency": "daily",
+      "severity": "debug"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-40-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.archive.device = '/disk0:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverity.debug
+    syslog.archive.frequency = xr_infra_syslog_cfg.LogCollectFrequency.daily
+    syslog.archive.size = 32
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-40-ydk.txt
@@ -1,0 +1,8 @@
+!! IOS XR Configuration version = 6.2.1
+logging archive
+ device disk0
+ severity debugging
+ frequency daily
+ archive-size 32
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.json
@@ -1,0 +1,12 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "archive": {
+      "size": 100,
+      "file-size": 10,
+      "device": "/harddisk:",
+      "severity": "informational",
+      "length": 52
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-42-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    syslog.archive.device = '/harddisk:'
+    syslog.archive.severity = xr_infra_syslog_cfg.LogMessageSeverity.informational
+    syslog.archive.file_size = 10
+    syslog.archive.size = 100
+    syslog.archive.length = 52
+    
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-42-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+logging archive
+ device harddisk
+ severity informational
+ file-size 10
+ archive-size 100
+ archive-length 52
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.json
@@ -1,0 +1,41 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "logging-facilities": {
+      "facility-level": "local0"
+    },
+    "host-server": {
+      "vrfs": {
+        "vrf": [
+          {
+            "vrf-name": "default",
+            "ipv4s": {
+              "ipv4": [
+                {
+                  "address": "10.0.0.1",
+                  "ipv4-severity-port": {
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "source-interface-table": {
+      "source-interface-values": {
+        "source-interface-value": [
+          {
+            "src-interface-name-value": "Loopback0",
+            "source-interface-vrfs": {
+              "source-interface-vrf": [
+                {
+                  "vrf-name": "default"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-50-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    #Facility
+    syslog.logging_facilities.facility_level = xr_infra_syslog_cfg.Facility.local0
+
+    #Hostserver
+    vrf = syslog.host_server.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    ipv4 = vrf.ipv4s.Ipv4()
+    ipv4.ipv4_severity_port = ipv4.Ipv4SeverityPort()
+    ipv4.address = "10.0.0.1"
+    vrf.ipv4s.ipv4.append(ipv4)
+    syslog.host_server.vrfs.vrf.append(vrf)
+
+    #Source-interface
+    source_interface_value = syslog.source_interface_table.source_interface_values.SourceInterfaceValue()
+    source_interface_value.src_interface_name_value = "Loopback0"
+    source_interface_vrf = source_interface_value.source_interface_vrfs.SourceInterfaceVrf()
+    source_interface_vrf.vrf_name = "default"
+    source_interface_value.source_interface_vrfs.source_interface_vrf.append(source_interface_vrf)
+    syslog.source_interface_table.source_interface_values.source_interface_value.append(source_interface_value)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-50-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+logging facility local0
+logging 10.0.0.1 vrf default
+logging source-interface Loopback0
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.json
@@ -1,0 +1,42 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "logging-facilities": {
+      "facility-level": "local0"
+    },
+    "host-server": {
+      "vrfs": {
+        "vrf": [
+          {
+            "vrf-name": "default",
+            "ipv6s": {
+              "ipv6": [
+                {
+                  "address": "2001:db8::a:1",
+                  "ipv6-severity-port": {
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "source-interface-table": {
+      "source-interface-values": {
+        "source-interface-value": [
+          {
+            "src-interface-name-value": "Loopback0",
+            "source-interface-vrfs": {
+              "source-interface-vrf": [
+                {
+                  "vrf-name": "default"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-51-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    #Facility
+    syslog.logging_facilities.facility_level = xr_infra_syslog_cfg.Facility.local0
+
+    #Hostserver
+    vrf = syslog.host_server.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    ipv6 = vrf.ipv6s.Ipv6()
+    ipv6.ipv6_severity_port = ipv6.Ipv6SeverityPort()
+    ipv6.address = "2001:db8::a:1"
+    vrf.ipv6s.ipv6.append(ipv6)
+    syslog.host_server.vrfs.vrf.append(vrf)
+
+    #Source-interface
+    source_interface_value = syslog.source_interface_table.source_interface_values.SourceInterfaceValue()
+    source_interface_value.src_interface_name_value = "Loopback0"
+    source_interface_vrf = source_interface_value.source_interface_vrfs.SourceInterfaceVrf()
+    source_interface_vrf.vrf_name = "default"
+    source_interface_value.source_interface_vrfs.source_interface_vrf.append(source_interface_vrf)
+    syslog.source_interface_table.source_interface_values.source_interface_value.append(source_interface_value)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-51-ydk.txt
@@ -1,0 +1,5 @@
+!! IOS XR Configuration version = 6.2.1
+logging facility local0
+logging 2001:db8::a:1 vrf default
+logging source-interface Loopback0
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.json
@@ -1,0 +1,57 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "host-name-prefix": "router",
+    "suppress-duplicates": [null],
+    "logging-facilities": {
+      "facility-level": "local0"
+    },
+    "host-server": {
+      "vrfs": {
+        "vrf": [
+          {
+            "vrf-name": "default",
+            "ipv4s": {
+              "ipv4": [
+                {
+                  "address": "10.0.0.1",
+                  "ipv4-severity-port": {
+                    "severity": 6
+                  }
+                },
+                {
+                  "address": "10.0.0.2",
+                  "ipv4-severity-port": {
+                    "severity": 6
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ipv4": {
+      "tos": {
+        "type": "dscp",
+        "dscp": "cs2"
+      }
+    },
+    "source-interface-table": {
+      "source-interface-values": {
+        "source-interface-value": [
+          {
+            "src-interface-name-value": "Loopback0",
+            "source-interface-vrfs": {
+              "source-interface-vrf": [
+                {
+                  "vrf-name": "default"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-52-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    #ipv4 TOS bit
+    syslog.ipv4.tos.type = xr_infra_syslog_cfg.LoggingTos.dscp
+    syslog.ipv4.tos.dscp = xr_infra_syslog_cfg.LoggingDscpValue.cs2
+
+    #Facility
+    syslog.logging_facilities.facility_level = xr_infra_syslog_cfg.Facility.local0
+
+    #Hostserver
+    vrf = syslog.host_server.vrfs.Vrf()
+    vrf.vrf_name = "default"
+    ipv4_1 = vrf.ipv4s.Ipv4()
+    ipv4_1.address = "10.0.0.1"
+    ipv4_severity_port = ipv4_1.Ipv4SeverityPort()
+    ipv4_severity_port.severity = 6
+    ipv4_1.ipv4_severity_port = ipv4_severity_port
+    ipv4_2 = vrf.ipv4s.Ipv4()
+    ipv4_2.address = "10.0.0.2"
+    ipv4_severity_port = ipv4_2.Ipv4SeverityPort()
+    ipv4_severity_port.severity = 6
+    ipv4_2.ipv4_severity_port = ipv4_severity_port
+    vrf.ipv4s.ipv4.append(ipv4_1)
+    vrf.ipv4s.ipv4.append(ipv4_2)
+    syslog.host_server.vrfs.vrf.append(vrf)
+
+    #Source-interface
+    source_interface_value = syslog.source_interface_table.source_interface_values.SourceInterfaceValue()
+    source_interface_value.src_interface_name_value = "Loopback0"
+    source_interface_vrf = source_interface_value.source_interface_vrfs.SourceInterfaceVrf()
+    source_interface_vrf.vrf_name = "default"
+    source_interface_value.source_interface_vrfs.source_interface_vrf.append(source_interface_vrf)
+    syslog.source_interface_table.source_interface_values.source_interface_value.append(source_interface_value)
+
+    #Host Name Prefix
+    syslog.host_name_prefix = "router"
+
+    # Suppression
+    syslog.suppress_duplicates = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-52-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+logging ipv4 dscp cs2
+logging facility local0
+logging 10.0.0.1 vrf MGMT-PLANE severity info
+logging 10.0.0.2 vrf MGMT-PLANE severity info
+logging source-interface Loopback0
+logging hostnameprefix router
+logging suppress duplicates
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.json
@@ -1,0 +1,57 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "host-name-prefix": "router",
+    "suppress-duplicates": [null],
+    "logging-facilities": {
+      "facility-level": "local0"
+    },
+    "host-server": {
+      "vrfs": {
+        "vrf": [
+          {
+            "vrf-name": "MGMT-PLANE",
+            "ipv6s": {
+              "ipv6": [
+                {
+                  "address": "2001:db8::a:1",
+                  "ipv6-severity-port": {
+                    "severity": 6
+                  }
+                },
+                {
+                  "address": "2001:db8::a:2",
+                  "ipv6-severity-port": {
+                    "severity": 6
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ipv4": {
+      "tos": {
+        "type": "dscp",
+        "dscp": "cs2"
+      }
+    },
+    "source-interface-table": {
+      "source-interface-values": {
+        "source-interface-value": [
+          {
+            "src-interface-name-value": "Loopback0",
+            "source-interface-vrfs": {
+              "source-interface-vrf": [
+                {
+                  "vrf-name": "default"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-53-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    #ipv4 TOS bit
+    syslog.ipv4.tos.type = xr_infra_syslog_cfg.LoggingTos.dscp
+    syslog.ipv4.tos.dscp = xr_infra_syslog_cfg.LoggingDscpValue.cs2
+
+    #Facility
+    syslog.logging_facilities.facility_level = xr_infra_syslog_cfg.Facility.local0
+
+    #Hostserver
+    vrf = syslog.host_server.vrfs.Vrf()
+    vrf.vrf_name = "MGMT-PLANE"
+    ipv6 = vrf.ipv6s.Ipv6()
+    ipv6.address = "2001:db8::a:1"
+    ipv6_severity_port = ipv6.Ipv6SeverityPort()
+    ipv6_severity_port.severity = 6
+    ipv6.ipv6_severity_port = ipv6_severity_port
+    vrf.ipv6s.ipv6.append(ipv6)
+    ipv6 = vrf.ipv6s.Ipv6()
+    ipv6.address = "2001:db8::a:2"
+    ipv6_severity_port = ipv6.Ipv6SeverityPort()
+    ipv6_severity_port.severity = 6
+    ipv6.ipv6_severity_port = ipv6_severity_port
+    vrf.ipv6s.ipv6.append(ipv6)
+    syslog.host_server.vrfs.vrf.append(vrf)
+
+    #Source-interface
+    source_interface_value = syslog.source_interface_table.source_interface_values.SourceInterfaceValue()
+    source_interface_value.src_interface_name_value = "Loopback0"
+    source_interface_vrf = source_interface_value.source_interface_vrfs.SourceInterfaceVrf()
+    source_interface_vrf.vrf_name = "default"
+    source_interface_value.source_interface_vrfs.source_interface_vrf.append(source_interface_vrf)
+    syslog.source_interface_table.source_interface_values.source_interface_value.append(source_interface_value)
+
+    #Host Name Prefix
+    syslog.host_name_prefix = "router"
+
+    # Suppression
+    syslog.suppress_duplicates = Empty()
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-53-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+logging ipv4 dscp cs2
+logging facility local0
+logging 2001:db8::a:1 vrf MGMT-PLANE severity info
+logging 2001:db8::a:2 vrf MGMT-PLANE severity info
+logging source-interface Loopback0
+logging hostnameprefix router
+logging suppress duplicates
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.json
@@ -1,0 +1,31 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "Cisco-IOS-XR-infra-correlator-cfg:suppression": {
+      "rules": {
+        "rule": [
+          {
+            "name": "RULE1",
+            "applied-to": {
+              "all": [null]
+            },
+            "alarm-causes": {
+              "alarm-cause": [
+                {
+                  "category": "MGBL",
+                  "group": "CONFIG",
+                  "code": "DB_COMMIT"
+                },
+                {
+                  "category": "SECURITY",
+                  "group": "LOGIN",
+                  "code": "AUTHEN_SUCCESS"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-60-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    rule = syslog.suppression.rules.Rule()
+    rule.name = "RULE1"
+    #DB_COMMIT Alarm
+    alarm_cause = rule.alarm_causes.AlarmCause()
+    alarm_cause.category = "MGBL"
+    alarm_cause.group = "CONFIG"
+    alarm_cause.code = "DB_COMMIT"
+    rule.alarm_causes.alarm_cause.append(alarm_cause)
+    #AUTHEN_SUCCESS alarm
+    alarm_cause = rule.alarm_causes.AlarmCause()
+    alarm_cause.category = "SECURITY"
+    alarm_cause.group = "LOGIN"
+    alarm_cause.code = "AUTHEN_SUCCESS"
+    rule.alarm_causes.alarm_cause.append(alarm_cause)
+    rule.applied_to.all = Empty()
+    syslog.suppression.rules.rule.append(rule)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-60-ydk.txt
@@ -1,0 +1,9 @@
+!! IOS XR Configuration version = 6.2.1
+logging suppress rule RULE1
+ alarm MGBL CONFIG DB_COMMIT
+ alarm SECURITY LOGIN AUTHEN_SUCCESS
+!
+logging suppress apply rule RULE1
+ all-of-router
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.json
@@ -1,0 +1,41 @@
+{
+  "Cisco-IOS-XR-infra-syslog-cfg:syslog": {
+    "Cisco-IOS-XR-infra-correlator-cfg:correlator": {
+      "buffer-size": 65535,
+      "rules": {
+        "rule": [
+          {
+            "name": "RULE2",
+            "non-stateful": {
+              "timeout-root-cause": 360000,
+              "timeout": 3600000,
+              "non-root-causes": {
+                "non-root-cause": [
+                  {
+                    "category": "PLATFORM",
+                    "group": "ENVMON",
+                    "message-code": "FAN_CLEAR"
+                  },
+                  {
+                    "category": "PLATFORM",
+                    "group": "ENVMON",
+                    "message-code": "FANTRAY_FAIL"
+                  }
+                ]
+              },
+              "root-cause": {
+                "category": "PLATFORM",
+                "group": "ENVMON",
+                "message-code": "FAN_FAIL"
+              }
+            },
+            "applied-to": {
+              "all": [null]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-syslog-cfg.
+
+usage: gn-set-xr-infra-syslog-cfg-62-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_syslog_cfg \
+    as xr_infra_syslog_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_syslog(syslog):
+    """Add config data to syslog object."""
+    #Rule Configuration
+    rule = syslog.correlator.rules.Rule()
+    rule.name = "RULE2"
+    # rule.non_stateful.conext_correlation = Empty() <--this should give error but doesn't
+    rule.non_stateful.timeout = 3600000
+    rule.non_stateful.root_cause.category = "PLATFORM"
+    rule.non_stateful.root_cause.group = "ENVMON"
+    rule.non_stateful.root_cause.message_code = "FAN_FAIL"
+    non_root_cause = rule.non_stateful.non_root_causes.NonRootCause()
+    non_root_cause.category = "PLATFORM"
+    non_root_cause.group = "ENVMON"
+    non_root_cause.message_code = "FAN_CLEAR"
+    rule.non_stateful.non_root_causes.non_root_cause.append(non_root_cause)
+    non_root_cause = rule.non_stateful.non_root_causes.NonRootCause()
+    non_root_cause.category = "PLATFORM"
+    non_root_cause.group = "ENVMON"
+    non_root_cause.message_code = "FANTRAY_FAIL"
+    rule.non_stateful.non_root_causes.non_root_cause.append(non_root_cause)
+    rule.non_stateful.timeout_root_cause = 360000
+    rule.applied_to.all = Empty()
+    syslog.correlator.rules.rule.append(rule)
+    syslog.correlator.buffer_size = 65535
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    syslog = xr_infra_syslog_cfg.Syslog()  # create object
+    config_syslog(syslog)  # add object configuration
+
+    # set configuration on gNMI device
+    syslog.yfilter = YFilter.replace
+    gnmi.set(provider, syslog)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-syslog-cfg/gn-set-xr-infra-syslog-cfg-62-ydk.txt
@@ -1,0 +1,15 @@
+!! IOS XR Configuration version = 6.2.1
+logging correlator rule RULE2 type nonstateful
+ timeout 360000
+ rootcause PLATFORM ENVMON FAN_FAIL
+ nonrootcause
+  alarm PLATFORM ENVMON FAN_CLEAR
+  alarm PLATFORM ENVMON FANTRAY_FAIL
+ !
+ timeout-rootcause 360000
+!
+logging correlator apply rule RULE2
+ all-of-router
+!
+logging correlator buffer-size 65535
+end


### PR DESCRIPTION
Includes four boilerplate and seventeen custom apps to configure syslog and
debug timestamps for XR data model using gNMI/gNMI:
gn-set-xr-infra-syslog-cfg-10-ydk.py - set boilerplate
gn-set-xr-infra-syslog-cfg-11-ydk.py - set boilerplate
gn-set-xr-infra-syslog-cfg-20-ydk.py - Disable log timestamps
gn-set-xr-infra-syslog-cfg-22-ydk.py - Uptime log timestamps
gn-set-xr-infra-syslog-cfg-24-ydk.py - Local time log timestamps
gn-set-xr-infra-syslog-cfg-26-ydk.py - Local time log/debug timest.
gn-set-xr-infra-syslog-cfg-28-ydk.py - Detailed log/debug timestamp
gn-set-xr-infra-syslog-cfg-30-ydk.py - Logging console disable
gn-set-xr-infra-syslog-cfg-32-ydk.py - Logging buffered
gn-set-xr-infra-syslog-cfg-40-ydk.py - Logging archive disk1
gn-set-xr-infra-syslog-cfg-42-ydk.py - Logging archive harddisk
gn-set-xr-infra-syslog-cfg-50-ydk.py - ipv4 remote logging server
gn-set-xr-infra-syslog-cfg-51-ydk.py - ipv6 remote logging server
gn-set-xr-infra-syslog-cfg-52-ydk.py - ipv4 remote logging server w/VRF
gn-set-xr-infra-syslog-cfg-53-ydk.py - ipv6 remote logging server w/VRF
gn-set-xr-infra-syslog-cfg-60-ydk.py - Logging suppression
gn-set-xr-infra-syslog-cfg-62-ydk.py - Logging correlation
gn-get-xr-infra-syslog-cfg-10-ydk.py - get boilerplate
gn-get-xr-infra-syslog-cfg-11-ydk.py - get boilerplate
gn-get-xr-infra-syslog-cfg-20-ydk.py - get syslog service
gn-get-xr-infra-syslog-cfg-21-ydk.py - get syslog