### PR TITLE
Add gNMI sample apps for time zone config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-get-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-get-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-get-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_clock(clock):
+    """Process data in clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+
+    # get data from gNMI device
+    # clock.yfilter = YFilter.read
+    # clock = gnmi.get(provider, clock)
+    process_clock(clock)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-get-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-get-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-get-xr-infra-infra-clock-linux-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_clock(clock):
+    """Process data in clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+
+    # get data from gNMI device
+    clock.yfilter = YFilter.read
+    clock = gnmi.get(provider, clock)
+    process_clock(clock)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    # clock.yfilter = YFilter.replace
+    # gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "PST",
+      "area-name": "PST8PDT"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "PST"
+    time_zone.area_name = "PST8PDT"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    clock.yfilter = YFilter.replace
+    gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.txt
@@ -1,0 +1,3 @@
+clock timezone PST PST8PDT
+end
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "CST",
+      "area-name": "PRC"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CST"
+    time_zone.area_name = "PRC"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    clock.yfilter = YFilter.replace
+    gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone CST PRC
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "CET",
+      "area-name": "CET"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "CET"
+    time_zone.area_name = "CET"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    clock.yfilter = YFilter.replace
+    gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone CET CET
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "BRT",
+      "area-name": "Brazil/East"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "BRT"
+    time_zone.area_name = "Brazil/East"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    clock.yfilter = YFilter.replace
+    gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone BRT Brazil/East
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.json
@@ -1,0 +1,9 @@
+{
+  "Cisco-IOS-XR-infra-infra-clock-linux-cfg:clock": {
+    "time-zone": {
+      "time-zone-name": "WAT",
+      "area-name": "Africa/Douala"
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-infra-infra-clock-linux-cfg.
+
+usage: gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_infra_infra_clock_linux_cfg \
+    as xr_infra_infra_clock_linux_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_clock(clock):
+    """Add config data to clock object."""
+    # time zone configuration
+    time_zone = clock.TimeZone()
+    time_zone.time_zone_name = "WAT"
+    time_zone.area_name = "Africa/Douala"
+    clock.time_zone = time_zone
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    clock = xr_infra_infra_clock_linux_cfg.Clock()  # create object
+    config_clock(clock)  # add object configuration
+
+    # set configuration on gNMI device
+    clock.yfilter = YFilter.replace
+    gnmi.set(provider, clock)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-infra-infra-clock-linux-cfg/gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.txt
@@ -1,0 +1,2 @@
+clock timezone WAT Africa/Douala
+end


### PR DESCRIPTION
Includes two boilerplate apps and six custom apps to configure
device time zone for XR data model using gNMI/gNMI:
gn-set-xr-infra-infra-clock-linux-cfg-10-ydk.py - set boilerplate
gn-set-xr-infra-infra-clock-linux-cfg-20-ydk.py - PST PST8PDT
gn-set-xr-infra-infra-clock-linux-cfg-22-ydk.py - CST PRC
gn-set-xr-infra-infra-clock-linux-cfg-24-ydk.py - CET CET
gn-set-xr-infra-infra-clock-linux-cfg-26-ydk.py - BRT Brazil/East
gn-set-xr-infra-infra-clock-linux-cfg-28-ydk.py - WAT Africa/Douala
gn-get-xr-infra-infra-clock-linux-cfg-10-ydk.py - get boilerplate
gn-get-xr-infra-infra-clock-linux-cfg-20-ydk.py - get device time zone