### PR TITLE
Add gNMI sample app for XR RSVP-TE config

### DIFF
--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-get-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-get-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-get-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_rsvp(rsvp):
+    """Process data in rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # get data from gNMI device
+    # rsvp.yfilter = YFilter.read
+    # rsvp = gnmi.get(provider, rsvp)
+    process_rsvp(rsvp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-get-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-get-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Get data for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-get-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def process_rsvp(rsvp):
+    """Process data in rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+
+    # get data from gNMI device
+    rsvp.yfilter = YFilter.read
+    rsvp = gnmi.get(provider, rsvp)
+    process_rsvp(rsvp)  # process object data
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-10-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-10-ydk.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-10-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    pass
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    # rsvp.yfilter = YFilter.replace
+    # gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.json
@@ -1,0 +1,31 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-20-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    rsvp.yfilter = YFilter.replace
+    gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-20-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth percentage 100
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth percentage 100
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "rdm-keyword": "not-specified",
+              "bc0-keyword": "not-specified"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-22-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.not_specified
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    rsvp.yfilter = YFilter.replace
+    gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-22-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth 1000000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth 1000000
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.json
@@ -1,0 +1,35 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "bc1-bandwidth": 25,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 100,
+              "bc1-bandwidth": 25,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool",
+              "bandwidth-mode": "percentage"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-24-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 100
+    interface.bandwidth.rdm.bc1_bandwidth = 25
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    interface.bandwidth.rdm.bandwidth_mode = xr_ip_rsvp_cfg.RsvpBwCfg.percentage
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    rsvp.yfilter = YFilter.replace
+    gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-24-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm percentage 100 sub-pool 25
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.json
@@ -1,0 +1,33 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "bc1-bandwidth": 250000,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool"
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "rdm": {
+              "bc0-bandwidth": 1000000,
+              "bc1-bandwidth": 250000,
+              "rdm-keyword": "rdm",
+              "bc0-keyword": "not-specified",
+              "bc1-keyword": "sub-pool"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-26-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.rdm.bc0_bandwidth = 1000000
+    interface.bandwidth.rdm.bc1_bandwidth = 250000
+    interface.bandwidth.rdm.rdm_keyword = xr_ip_rsvp_cfg.RsvpRdm.rdm
+    interface.bandwidth.rdm.bc0_keyword = xr_ip_rsvp_cfg.RsvpBc0.not_specified
+    interface.bandwidth.rdm.bc1_keyword = xr_ip_rsvp_cfg.RsvpBc1.sub_pool
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    rsvp.yfilter = YFilter.update
+    gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-26-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth rdm 1000000 sub-pool 250000
+ !
+!
+end

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.json
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.json
@@ -1,0 +1,29 @@
+{
+  "Cisco-IOS-XR-ip-rsvp-cfg:rsvp": {
+    "interfaces": {
+      "interface": [
+        {
+          "name": "GigabitEthernet0/0/0/0",
+          "bandwidth": {
+            "mam": {
+              "max-resv-bandwidth": 1000000,
+              "bc0-bandwidth": 600000,
+              "bc1-bandwidth": 400000
+            }
+          }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1",
+          "bandwidth": {
+            "mam": {
+              "max-resv-bandwidth": 1000000,
+              "bc0-bandwidth": 600000,
+              "bc1-bandwidth": 400000
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.py
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Set configuration for model Cisco-IOS-XR-ip-rsvp-cfg.
+
+usage: gn-set-xr-ip-rsvp-cfg-28-ydk.py [-h] [-v] device
+
+positional arguments:
+  device         gNMI device (http://user:password@host:port)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.path import Repository
+from ydk.filters import YFilter
+from ydk.gnmi.services import gNMIService
+from ydk.gnmi.providers import gNMIServiceProvider
+from ydk.models.cisco_ios_xr import Cisco_IOS_XR_ip_rsvp_cfg \
+    as xr_ip_rsvp_cfg
+from ydk.types import Empty
+import os
+import logging
+
+
+YDK_REPO_DIR = os.path.expanduser("~/.ydk/")
+
+def config_rsvp(rsvp):
+    """Add config data to rsvp object."""
+    # RSVP interface gig0/0/0/0
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/0"
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+    # RSVP interface gig0/0/0/1
+    interface = rsvp.interfaces.Interface()
+    interface.name = "GigabitEthernet0/0/0/1"
+    interface.bandwidth.mam.max_resv_bandwidth = 1000000
+    interface.bandwidth.mam.bc0_bandwidth = 600000
+    interface.bandwidth.mam.bc1_bandwidth = 400000
+    rsvp.interfaces.interface.append(interface)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    parser.add_argument("device",
+                        help="gNMI device (http://user:password@host:port)")
+    args = parser.parse_args()
+    device = urlparse(args.device)
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create gNMI provider
+    repository = Repository(YDK_REPO_DIR+device.hostname)
+    provider = gNMIServiceProvider(repo=repository,
+                                   address=device.hostname,
+                                   port=device.port,
+                                   username=device.username,
+                                   password=device.password)
+    # create gNMI service
+    gnmi = gNMIService()
+
+    rsvp = xr_ip_rsvp_cfg.Rsvp()  # create object
+    config_rsvp(rsvp)  # add object configuration
+
+    # set configuration on gNMI device
+    rsvp.yfilter = YFilter.replace
+    gnmi.set(provider, rsvp)
+
+    exit()
+# End of script

--- a/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.txt
+++ b/samples/basic/gnmi/models/cisco-ios-xr/Cisco-IOS-XR-ip-rsvp-cfg/gn-set-xr-ip-rsvp-cfg-28-ydk.txt
@@ -1,0 +1,10 @@
+!! IOS XR Configuration version = 6.1.1
+rsvp
+ interface GigabitEthernet0/0/0/0
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+ interface GigabitEthernet0/0/0/1
+  bandwidth mam max-reservable-bw 1000000 bc0 600000 bc1 400000
+ !
+!
+end


### PR DESCRIPTION
Includes two boilerplate and six custom apps to configure RSVP-TE (non-DS-TE and DS-TE with RDM/MAM bandwidth pools) for XR data model using gNMI/gNMI:

gn-set-xr-ip-rsvp-cfg-10-ydk.py - set boilerplate
gn-set-xr-ip-rsvp-cfg-20-ydk.py - interface BW percentage
gn-set-xr-ip-rsvp-cfg-22-ydk.py - interface BW absolute
gn-set-xr-ip-rsvp-cfg-24-ydk.py - interface RDM BW percentage
gn-set-xr-ip-rsvp-cfg-26-ydk.py - interface RDM BW absolute
gn-set-xr-ip-rsvp-cfg-28-ydk.py - interface MAM BW
gn-get-xr-ip-rsvp-cfg-10-ydk.py - get boilerplate
gn-get-xr-ip-rsvp-cfg-20-ydk.py - get RSVP-TE